### PR TITLE
ci: add WASM size reporting and optimization step

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -43,3 +43,27 @@ jobs:
 
       - name: Build WASM (release)
         run: cargo build --release --target wasm32-unknown-unknown
+      - name: Report WASM binary size
+        run: ls -lh target/wasm32-unknown-unknown/release/crowdfund.wasm
+
+      - name: Install wasm-opt (Binaryen)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y binaryen
+
+      - name: Optimize WASM with wasm-opt
+        run: |
+          wasm-opt -Oz \
+            target/wasm32-unknown-unknown/release/crowdfund.wasm \
+            -o target/wasm32-unknown-unknown/release/crowdfund.opt.wasm
+
+      - name: Fail if WASM exceeds 256 KB
+        run: |
+          SIZE=$(stat -c%s target/wasm32-unknown-unknown/release/crowdfund.opt.wasm)
+          MAX=$((256 * 1024))
+          if [ "$SIZE" -gt "$MAX" ]; then
+            echo "WASM binary too large: $SIZE bytes (max $MAX bytes)"
+            exit 1
+          else
+            echo "WASM size OK: $SIZE bytes"
+          fi


### PR DESCRIPTION
Add CI step to report WASM binary size after build using ls -lh Install wasm-opt from Binaryen and optimize output with -Oz flag Fail CI if optimized WASM binary exceeds 256 KB size threshold. Closes #13