### PR TITLE
feat: add get_campaign_info view function and creator helper

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -29,6 +29,16 @@ pub struct CampaignStats {
 
 #[derive(Clone)]
 #[contracttype]
+pub struct CampaignInfo {
+    pub creator: Address,
+    pub token: Address,
+    pub goal: i128,
+    pub deadline: u64,
+    pub total_raised: i128,
+}
+
+#[derive(Clone)]
+#[contracttype]
 pub enum DataKey {
     /// The address of the campaign creator.
     Creator,
@@ -309,6 +319,28 @@ impl CrowdfundContract {
     /// Returns the minimum contribution amount.
     pub fn min_contribution(env: Env) -> i128 {
         env.storage().instance().get(&DataKey::MinContribution).unwrap()
+    }
+
+    /// Returns the campaign creator's address.
+    pub fn creator(env: Env) -> Address {
+        env.storage().instance().get(&DataKey::Creator).unwrap()
+    }
+
+    /// Returns complete campaign information in a single call.
+    pub fn get_campaign_info(env: Env) -> CampaignInfo {
+        let creator: Address = env.storage().instance().get(&DataKey::Creator).unwrap();
+        let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
+        let goal: i128 = env.storage().instance().get(&DataKey::Goal).unwrap();
+        let deadline: u64 = env.storage().instance().get(&DataKey::Deadline).unwrap();
+        let total_raised: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap_or(0);
+
+        CampaignInfo {
+            creator,
+            token,
+            goal,
+            deadline,
+            total_raised,
+        }
     }
 
     /// Returns comprehensive campaign statistics.

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -507,3 +507,83 @@ fn test_stats_progress_capped_at_10000() {
     assert_eq!(stats.average_contribution, 1_500_000);
     assert_eq!(stats.largest_contribution, 1_500_000);
 }
+
+// ── Campaign Info Tests ────────────────────────────────────────────────────
+
+#[test]
+fn test_creator() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution);
+
+    assert_eq!(client.creator(), creator);
+}
+
+#[test]
+fn test_get_campaign_info_initial() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution);
+
+    let info = client.get_campaign_info();
+
+    assert_eq!(info.creator, creator);
+    assert_eq!(info.token, token_address);
+    assert_eq!(info.goal, goal);
+    assert_eq!(info.deadline, deadline);
+    assert_eq!(info.total_raised, 0);
+}
+
+#[test]
+fn test_get_campaign_info_with_contributions() {
+    let (env, client, creator, token_address, admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution);
+
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    mint_to(&env, &token_address, &admin, &alice, 600_000);
+    mint_to(&env, &token_address, &admin, &bob, 300_000);
+
+    client.contribute(&alice, &600_000);
+    client.contribute(&bob, &300_000);
+
+    let info = client.get_campaign_info();
+
+    assert_eq!(info.creator, creator);
+    assert_eq!(info.token, token_address);
+    assert_eq!(info.goal, goal);
+    assert_eq!(info.deadline, deadline);
+    assert_eq!(info.total_raised, 900_000);
+}
+
+#[test]
+fn test_get_campaign_info_after_goal_reached() {
+    let (env, client, creator, token_address, admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution);
+
+    let contributor = Address::generate(&env);
+    mint_to(&env, &token_address, &admin, &contributor, 1_500_000);
+    client.contribute(&contributor, &1_500_000);
+
+    let info = client.get_campaign_info();
+
+    assert_eq!(info.creator, creator);
+    assert_eq!(info.token, token_address);
+    assert_eq!(info.goal, goal);
+    assert_eq!(info.deadline, deadline);
+    assert_eq!(info.total_raised, 1_500_000);
+}


### PR DESCRIPTION
Define CampaignInfo struct with creator, token, goal, deadline, total_raised fields Implement get_campaign_info(env: Env) -> CampaignInfo returning full campaign state Add creator(env: Env) -> Address public view helper to expose creator address Write tests covering get_campaign_info and creator return values

Closes #6