### PR TITLE
feat: implement stretch-goal mechanism

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -99,6 +99,8 @@ pub enum DataKey {
     SocialLinks,
     /// Platform configuration for fee handling.
     PlatformConfig,
+    /// List of stretch goal milestones above the primary goal.
+    StretchGoals,
 }
 
 // ── Contract Error ──────────────────────────────────────────────────────────
@@ -523,6 +525,56 @@ impl CrowdfundContract {
             .instance()
             .get(&DataKey::Roadmap)
             .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Add a stretch goal milestone to the campaign.
+    ///
+    /// Only the creator can add stretch goals. The milestone must be greater
+    /// than the primary goal.
+    pub fn add_stretch_goal(env: Env, milestone: i128) {
+        let creator: Address = env.storage().instance().get(&DataKey::Creator).unwrap();
+        creator.require_auth();
+
+        let goal: i128 = env.storage().instance().get(&DataKey::Goal).unwrap();
+        if milestone <= goal {
+            panic!("stretch goal must be greater than primary goal");
+        }
+
+        let mut stretch_goals: Vec<i128> = env
+            .storage()
+            .instance()
+            .get(&DataKey::StretchGoals)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        stretch_goals.push_back(milestone);
+        env.storage()
+            .instance()
+            .set(&DataKey::StretchGoals, &stretch_goals);
+    }
+
+    /// Returns the next unmet stretch goal milestone.
+    ///
+    /// Returns 0 if there are no stretch goals or all have been met.
+    pub fn current_milestone(env: Env) -> i128 {
+        let total_raised: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalRaised)
+            .unwrap_or(0);
+
+        let stretch_goals: Vec<i128> = env
+            .storage()
+            .instance()
+            .get(&DataKey::StretchGoals)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        for milestone in stretch_goals.iter() {
+            if total_raised < milestone {
+                return milestone;
+            }
+        }
+
+        0
     }
     pub fn total_raised(env: Env) -> i128 {
         env.storage()

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -1223,3 +1223,216 @@ fn test_update_metadata_after_cancel_panics() {
 // Note: The non-creator test would require complex mock setup.
 // The authorization check is covered by require_auth() in the contract,
 // which will panic if the caller is not the creator.
+
+// ── Stretch Goal Tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_add_single_stretch_goal() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    let stretch_goal: i128 = 2_000_000;
+    client.add_stretch_goal(&stretch_goal);
+
+    assert_eq!(client.current_milestone(), stretch_goal);
+}
+
+#[test]
+fn test_add_multiple_stretch_goals() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    client.add_stretch_goal(&2_000_000);
+    client.add_stretch_goal(&3_000_000);
+    client.add_stretch_goal(&5_000_000);
+
+    // Should return the first unmet milestone
+    assert_eq!(client.current_milestone(), 2_000_000);
+}
+
+#[test]
+fn test_current_milestone_updates_after_reaching() {
+    let (env, client, creator, token_address, admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    client.add_stretch_goal(&2_000_000);
+    client.add_stretch_goal(&3_000_000);
+
+    // Initially, first stretch goal is current
+    assert_eq!(client.current_milestone(), 2_000_000);
+
+    // Contribute to reach first stretch goal
+    let contributor = Address::generate(&env);
+    mint_to(&env, &token_address, &admin, &contributor, 2_500_000);
+    client.contribute(&contributor, &2_500_000);
+
+    // Now second stretch goal should be current
+    assert_eq!(client.current_milestone(), 3_000_000);
+}
+
+#[test]
+fn test_current_milestone_returns_zero_when_all_met() {
+    let (env, client, creator, token_address, admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    client.add_stretch_goal(&2_000_000);
+    client.add_stretch_goal(&3_000_000);
+
+    // Contribute to exceed all stretch goals
+    let contributor = Address::generate(&env);
+    mint_to(&env, &token_address, &admin, &contributor, 4_000_000);
+    client.contribute(&contributor, &4_000_000);
+
+    // All stretch goals met, should return 0
+    assert_eq!(client.current_milestone(), 0);
+}
+
+#[test]
+fn test_current_milestone_returns_zero_when_no_stretch_goals() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    // No stretch goals added
+    assert_eq!(client.current_milestone(), 0);
+}
+
+#[test]
+#[should_panic(expected = "stretch goal must be greater than primary goal")]
+fn test_add_stretch_goal_below_primary_goal_panics() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    // Try to add stretch goal below primary goal
+    client.add_stretch_goal(&500_000);
+}
+
+#[test]
+#[should_panic(expected = "stretch goal must be greater than primary goal")]
+fn test_add_stretch_goal_equal_to_primary_goal_panics() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    // Try to add stretch goal equal to primary goal
+    client.add_stretch_goal(&1_000_000);
+}
+
+#[test]
+#[should_panic]
+fn test_add_stretch_goal_by_non_creator_panics() {
+    let env = Env::default();
+    let contract_id = env.register(crate::CrowdfundContract, ());
+    let client = crate::CrowdfundContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin.clone());
+    let token_address = token_contract_id.address();
+
+    let creator = Address::generate(&env);
+    let non_creator = Address::generate(&env);
+
+    env.mock_all_auths();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &None,
+    );
+
+    env.mock_all_auths_allowing_non_root_auth();
+    env.set_auths(&[]);
+
+    client.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &non_creator,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "add_stretch_goal",
+            args: soroban_sdk::vec![&env],
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.add_stretch_goal(&2_000_000);
+}


### PR DESCRIPTION
Closes #20 
Add DataKey::StretchGoals storing a Vec of ordered milestones Implement add_stretch_goal(env, milestone: i128) restricted to creator only, enforcing milestone must be greater than primary goal Implement pub fn current_milestone(env: Env) -> i128 returning the next unmet milestone from the stretch goals list
Write tests for adding single and multiple stretch goals Write tests for reaching stretch goal milestones and verifying current_milestone updates Write tests rejecting stretch goals set below or equal to the primary goal Write tests rejecting add_stretch_goal calls from non-creator addresses

Closes #20