### PR TITLE
Pull Request: Add GitHub Action to Auto-Close Stale Issues  and PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,46 @@
+name: Mark Stale Issues and PRs
+on:
+  schedule:
+    - cron: "0 0 * * *" # runs daily at midnight UTC
+  workflow_dispatch: # allow manual trigger
+
+jobs:
+  stale:
+    name: Auto-close stale issues and PRs
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Mark stale issues and pull requests
+        uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          days-before-close: 7
+          stale-issue-label: "stale"
+          stale-issue-message: >
+            👋 This issue has been inactive for 30 days and has been marked
+            as stale. If this is still relevant, please leave a comment or
+            update the issue to keep it open. It will be automatically closed
+            in 7 days if there is no further activity.
+          close-issue-message: >
+            🔒 This issue has been automatically closed due to inactivity.
+            If you believe this is still relevant, feel free to reopen it
+            with updated context.
+          stale-pr-label: "stale"
+          stale-pr-message: >
+            👋 This pull request has been inactive for 30 days and has been
+            marked as stale. If this is still in progress, please leave a
+            comment or push an update to keep it open. It will be
+            automatically closed in 7 days if there is no further activity.
+          close-pr-message: >
+            🔒 This pull request has been automatically closed due to
+            inactivity. If you would like to continue this work, feel free
+            to reopen it or open a new PR with updated changes.
+          exempt-issue-labels: "pinned,security,in-progress,blocked"
+          exempt-pr-labels: "pinned,security,in-progress,blocked"
+          exempt-all-milestones: true
+          remove-stale-when-updated: true
+          operations-per-run: 100
+          ascending: true


### PR DESCRIPTION
This PR implements an automated housekeeping workflow using the official actions/stale@v9 action. It is designed to keep the repository backlog healthy by identifying inactive issues and pull requests, marking them with a stale label, and eventually closing them if no further activity occurs.

Changes
- Added .github/workflows/stale.yml.
- Configured to run daily at 00:00 UTC via cron.
- Added workflow_dispatch to allow maintainers to trigger the stale check manually.
- Mark Stale after 30 days of inactivity.
- Auto-Close: 7 days after being marked as stale.
- Exemptions: * Items with labels: pinned, security, in-progress, or blocked.
- Any issue or PR assigned to a Milestone.

Technical Implementation Details
The workflow uses the following cron expression:
cron: "0 0 * * *"

This breaks down to: Minute 0, Hour 0 (Midnight), Every Day, Every Month, Every Day of the Week.

Checklist
[x] Workflow file created in the correct .github/workflows/ directory.

[x] YAML syntax validated.

[x] Friendly notification messages included for both issues and PRs.

[x] Milestone exemption enabled to protect high-priority roadmap items.

[x] Permissions set to write for issues and PRs to allow the bot to label and comment.

Closes #163 