### PR TITLE
feat: add on-chain campaign updates blog for creators

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 #![allow(missing_docs)]
 
-use soroban_sdk::{contract, contractimpl, contracterror, contracttype, token, Address, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, token, Address, Env, String, Symbol, Vec,
+};
 
 #[cfg(test)]
 mod test;
@@ -146,6 +148,12 @@ pub enum DataKey {
     TotalPledged,
     /// List of stretch goal milestones.
     StretchGoals,
+    /// Campaign updates blog: Vec<(u64, String)> of (timestamp, update text).
+    Updates,
+    /// Whether whitelist is enabled for this campaign.
+    WhitelistEnabled,
+    /// Individual whitelist entry by address.
+    Whitelist(Address),
 }
 
 // ── Rate Limiting ──────────────────────────────────────────────────────────
@@ -212,16 +220,6 @@ impl CrowdfundContract {
             return Err(ContractError::AlreadyInitialized);
         }
 
-        let eb_deadline = match early_bird_deadline {
-            Some(eb) => {
-                if eb >= deadline {
-                    panic!("early bird deadline must be before campaign deadline");
-                }
-                eb
-            }
-            None => core::cmp::min(env.ledger().timestamp() + 86400, deadline.saturating_sub(1)),
-        };
-
         creator.require_auth();
 
         // Validate platform fee if provided.
@@ -240,7 +238,9 @@ impl CrowdfundContract {
             .instance()
             .set(&DataKey::MinContribution, &min_contribution);
         env.storage().instance().set(&DataKey::Title, &title);
-        env.storage().instance().set(&DataKey::Description, &description);
+        env.storage()
+            .instance()
+            .set(&DataKey::Description, &description);
         env.storage().instance().set(&DataKey::TotalRaised, &0i128);
         env.storage()
             .instance()
@@ -282,11 +282,15 @@ impl CrowdfundContract {
         creator.require_auth();
 
         if !env.storage().instance().has(&DataKey::WhitelistEnabled) {
-            env.storage().instance().set(&DataKey::WhitelistEnabled, &true);
+            env.storage()
+                .instance()
+                .set(&DataKey::WhitelistEnabled, &true);
         }
 
         for address in addresses.iter() {
-            env.storage().instance().set(&DataKey::Whitelist(address), &true);
+            env.storage()
+                .instance()
+                .set(&DataKey::Whitelist(address), &true);
         }
     }
 
@@ -608,11 +612,7 @@ impl CrowdfundContract {
         }
 
         // Update global total raised.
-        let total: i128 = env
-            .storage()
-            .instance()
-            .get(&DataKey::TotalRaised)
-            .unwrap();
+        let total: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap();
         env.storage()
             .instance()
             .set(&DataKey::TotalRaised, &(total - amount));
@@ -773,22 +773,20 @@ impl CrowdfundContract {
         token_client.transfer(&env.current_contract_address(), &contributor, &amount);
 
         // Reset the contributor's contribution to 0.
-        env.storage()
-            .persistent()
-            .set(&contribution_key, &0i128);
+        env.storage().persistent().set(&contribution_key, &0i128);
         env.storage()
             .persistent()
             .extend_ttl(&contribution_key, 100, 100);
 
         // Update total raised.
         let new_total = total - amount;
-        env.storage().instance().set(&DataKey::TotalRaised, &new_total);
+        env.storage()
+            .instance()
+            .set(&DataKey::TotalRaised, &new_total);
 
         // Emit refund event
-        env.events().publish(
-            ("campaign", "refunded"),
-            (contributor.clone(), amount),
-        );
+        env.events()
+            .publish(("campaign", "refunded"), (contributor.clone(), amount));
 
         Ok(())
     }
@@ -974,6 +972,43 @@ impl CrowdfundContract {
         env.storage()
             .instance()
             .get(&DataKey::Roadmap)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    /// Post a campaign update (creator only).
+    ///
+    /// Records the current timestamp and the provided text. Rejects empty text.
+    /// Emits a (campaign, update_posted) event with timestamp and text.
+    pub fn post_update(env: Env, text: String) {
+        let creator: Address = env.storage().instance().get(&DataKey::Creator).unwrap();
+        creator.require_auth();
+
+        if text.is_empty() {
+            panic!("update text cannot be empty");
+        }
+
+        let timestamp = env.ledger().timestamp();
+
+        let mut updates: Vec<(u64, String)> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Updates)
+            .unwrap_or_else(|| Vec::new(&env));
+
+        updates.push_back((timestamp, text.clone()));
+
+        env.storage().instance().set(&DataKey::Updates, &updates);
+        env.events()
+            .publish(("campaign", "update_posted"), (timestamp, text));
+    }
+
+    /// Returns the full ordered list of campaign updates.
+    ///
+    /// Each entry is a tuple of (timestamp, update text) in chronological order.
+    pub fn get_updates(env: Env) -> Vec<(u64, String)> {
+        env.storage()
+            .instance()
+            .get(&DataKey::Updates)
             .unwrap_or_else(|| Vec::new(&env))
     }
 
@@ -1171,9 +1206,21 @@ impl CrowdfundContract {
         let token: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let goal: i128 = env.storage().instance().get(&DataKey::Goal).unwrap();
         let deadline: u64 = env.storage().instance().get(&DataKey::Deadline).unwrap();
-        let total_raised: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap_or(0);
-        let title: String = env.storage().instance().get(&DataKey::Title).unwrap_or_else(|| String::from_str(&env, ""));
-        let description: String = env.storage().instance().get(&DataKey::Description).unwrap_or_else(|| String::from_str(&env, ""));
+        let total_raised: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::TotalRaised)
+            .unwrap_or(0);
+        let title: String = env
+            .storage()
+            .instance()
+            .get(&DataKey::Title)
+            .unwrap_or_else(|| String::from_str(&env, ""));
+        let description: String = env
+            .storage()
+            .instance()
+            .get(&DataKey::Description)
+            .unwrap_or_else(|| String::from_str(&env, ""));
 
         CampaignInfo {
             creator,
@@ -1185,7 +1232,7 @@ impl CrowdfundContract {
             description,
         }
     }
- 
+
     /// Returns true if the address is whitelisted.
     pub fn is_whitelisted(env: Env, address: Address) -> bool {
         env.storage()

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -1,6 +1,9 @@
 #![cfg(test)]
 
-use soroban_sdk::{testutils::{Address as _, Ledger, Events}, token, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, Events, Ledger},
+    token, Address, Env,
+};
 
 use crate::{CrowdfundContract, CrowdfundContractClient};
 
@@ -100,7 +103,16 @@ fn test_double_initialize_panics() {
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
 
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
     let result = client.try_initialize(
         &creator,
         &token_address,
@@ -127,7 +139,16 @@ fn test_contribute() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 500_000);
@@ -145,7 +166,16 @@ fn test_multiple_contributions() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
@@ -167,7 +197,16 @@ fn test_contribute_after_deadline_panics() {
     let deadline = env.ledger().timestamp() + 100;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     // Fast-forward past the deadline.
     env.ledger().set_timestamp(deadline + 1);
@@ -191,7 +230,16 @@ fn test_withdraw_after_goal_met() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 1_000_000);
@@ -219,7 +267,16 @@ fn test_withdraw_before_deadline_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 1_000_000);
@@ -241,7 +298,16 @@ fn test_withdraw_goal_not_reached_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 500_000);
@@ -266,7 +332,16 @@ fn test_refund_single_when_goal_not_met() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let alice = Address::generate(&env);
     let bob = Address::generate(&env);
@@ -296,7 +371,16 @@ fn test_refund_when_goal_reached_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 1_000_000);
@@ -305,7 +389,7 @@ fn test_refund_when_goal_reached_panics() {
     env.ledger().set_timestamp(deadline + 1);
 
     let result = client.try_refund_single(&contributor);
-    
+
     assert!(result.is_err());
     assert_eq!(
         result.unwrap_err().unwrap(),
@@ -319,7 +403,16 @@ fn test_refund_single_before_deadline_fails() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 500_000);
@@ -329,9 +422,11 @@ fn test_refund_single_before_deadline_fails() {
     let result = client.try_refund_single(&contributor);
 
     assert!(result.is_err());
-    assert_eq!(result.unwrap_err().unwrap(), crate::ContractError::CampaignStillActive);
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        crate::ContractError::CampaignStillActive
+    );
 }
-
 
 // ── Bug Condition Exploration Test ─────────────────────────────────────────
 
@@ -358,10 +453,28 @@ fn test_bug_condition_exploration_all_error_conditions_panic() {
         let (env, client, creator, token_address, _admin) = setup_env();
         let deadline = env.ledger().timestamp() + 3600;
         let goal: i128 = 1_000_000;
-        
-        client.initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        let result = client.try_initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        
+
+        client.initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+        let result = client.try_initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().unwrap(),
@@ -374,8 +487,17 @@ fn test_bug_condition_exploration_all_error_conditions_panic() {
         let (env, client, creator, token_address, admin) = setup_env();
         let deadline = env.ledger().timestamp() + 100;
         let goal: i128 = 1_000_000;
-        client.initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        
+        client.initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+
         env.ledger().set_timestamp(deadline + 1);
 
         let contributor = Address::generate(&env);
@@ -391,8 +513,17 @@ fn test_bug_condition_exploration_all_error_conditions_panic() {
         let (env, client, creator, token_address, admin) = setup_env();
         let deadline = env.ledger().timestamp() + 3600;
         let goal: i128 = 1_000_000;
-        client.initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        
+        client.initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+
         let contributor = Address::generate(&env);
         mint_to(&env, &token_address, &admin, &contributor, 1_000_000);
         client.contribute(&contributor, &1_000_000);
@@ -411,8 +542,17 @@ fn test_bug_condition_exploration_all_error_conditions_panic() {
         let (env, client, creator, token_address, admin) = setup_env();
         let deadline = env.ledger().timestamp() + 3600;
         let goal: i128 = 1_000_000;
-        client.initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        
+        client.initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+
         let contributor = Address::generate(&env);
         mint_to(&env, &token_address, &admin, &contributor, 500_000);
         client.contribute(&contributor, &500_000);
@@ -429,14 +569,23 @@ fn test_bug_condition_exploration_all_error_conditions_panic() {
         let (env, client, creator, token_address, admin) = setup_env();
         let deadline = env.ledger().timestamp() + 3600;
         let goal: i128 = 1_000_000;
-        client.initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        
+        client.initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+
         let contributor = Address::generate(&env);
         mint_to(&env, &token_address, &admin, &contributor, 500_000);
         client.contribute(&contributor, &500_000);
-        
+
         let result = client.try_refund_single(&contributor);
-        
+
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().unwrap(),
@@ -449,15 +598,24 @@ fn test_bug_condition_exploration_all_error_conditions_panic() {
         let (env, client, creator, token_address, admin) = setup_env();
         let deadline = env.ledger().timestamp() + 3600;
         let goal: i128 = 1_000_000;
-        client.initialize(&creator, &token_address, &goal, &deadline, &1_000, &default_title(&env), &default_description(&env), &None);
-        
+        client.initialize(
+            &creator,
+            &token_address,
+            &goal,
+            &deadline,
+            &1_000,
+            &default_title(&env),
+            &default_description(&env),
+            &None,
+        );
+
         let contributor = Address::generate(&env);
         mint_to(&env, &token_address, &admin, &contributor, 1_000_000);
         client.contribute(&contributor, &1_000_000);
 
         env.ledger().set_timestamp(deadline + 1);
         let result = client.try_refund_single(&contributor);
-        
+
         assert!(result.is_err());
         assert_eq!(result.unwrap_err().unwrap(), ContractError::GoalReached);
     }
@@ -644,7 +802,16 @@ fn test_double_withdraw_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 1_000_000);
@@ -663,7 +830,16 @@ fn test_double_refund_single_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let alice = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &alice, 500_000);
@@ -749,7 +925,16 @@ fn test_contribute_above_minimum() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 10_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let contributor = Address::generate(&env);
     mint_to(&env, &token_address, &admin, &contributor, 50_000);
@@ -769,7 +954,16 @@ fn test_get_user_tier_bronze_level() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 10_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let bronze = soroban_sdk::String::from_str(&env, "Bronze");
     let silver = soroban_sdk::String::from_str(&env, "Silver");
@@ -794,7 +988,16 @@ fn test_get_user_tier_gold_level() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 10_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let bronze = soroban_sdk::String::from_str(&env, "Bronze");
     let silver = soroban_sdk::String::from_str(&env, "Silver");
@@ -819,7 +1022,16 @@ fn test_get_user_tier_non_contributor_returns_none() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let bronze = soroban_sdk::String::from_str(&env, "Bronze");
     client.add_reward_tier(&creator, &bronze, &10_000);
@@ -1002,7 +1214,16 @@ fn test_add_multiple_roadmap_items_in_order() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let current_time = env.ledger().timestamp();
     let date1 = current_time + 86400;
@@ -1035,7 +1256,16 @@ fn test_add_roadmap_item_with_past_date_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let current_time = env.ledger().timestamp();
     // Set a past date by moving time forward first, then trying to add an item with an earlier date
@@ -1054,7 +1284,16 @@ fn test_add_roadmap_item_with_current_date_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let current_time = env.ledger().timestamp();
     let description = soroban_sdk::String::from_str(&env, "Current milestone");
@@ -1070,7 +1309,16 @@ fn test_add_roadmap_item_with_empty_description_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let current_time = env.ledger().timestamp();
     let roadmap_date = current_time + 86400;
@@ -1098,7 +1346,16 @@ fn test_add_roadmap_item_by_non_creator_panics() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     env.mock_all_auths_allowing_non_root_auth();
     env.set_auths(&[]);
@@ -1127,10 +1384,190 @@ fn test_roadmap_empty_after_initialization() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let roadmap = client.roadmap();
     assert_eq!(roadmap.len(), 0);
+}
+
+// ── Campaign Updates Tests ─────────────────────────────────────────────────
+
+#[test]
+fn test_post_single_update() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let hard_cap: i128 = goal * 2;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &hard_cap,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
+
+    let update_text = soroban_sdk::String::from_str(&env, "Development milestone reached!");
+    client.post_update(&update_text);
+
+    let updates = client.get_updates();
+    assert_eq!(updates.len(), 1);
+    let (timestamp, text) = updates.get(0).unwrap();
+    assert_eq!(timestamp, env.ledger().timestamp());
+    assert_eq!(text, update_text);
+}
+
+#[test]
+fn test_post_multiple_updates_chronological_order() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let hard_cap: i128 = goal * 2;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &hard_cap,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
+
+    let update1 = soroban_sdk::String::from_str(&env, "First update");
+    let time1 = env.ledger().timestamp();
+    client.post_update(&update1);
+
+    env.ledger().set_timestamp(time1 + 100);
+    let update2 = soroban_sdk::String::from_str(&env, "Second update");
+    let time2 = env.ledger().timestamp();
+    client.post_update(&update2);
+
+    env.ledger().set_timestamp(time2 + 200);
+    let update3 = soroban_sdk::String::from_str(&env, "Third update");
+    let time3 = env.ledger().timestamp();
+    client.post_update(&update3);
+
+    let updates = client.get_updates();
+    assert_eq!(updates.len(), 3);
+
+    let (ts1, text1) = updates.get(0).unwrap();
+    assert_eq!(ts1, time1);
+    assert_eq!(text1, update1);
+
+    let (ts2, text2) = updates.get(1).unwrap();
+    assert_eq!(ts2, time2);
+    assert_eq!(text2, update2);
+
+    let (ts3, text3) = updates.get(2).unwrap();
+    assert_eq!(ts3, time3);
+    assert_eq!(text3, update3);
+}
+
+#[test]
+#[should_panic]
+fn test_post_update_by_non_creator_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(CrowdfundContract, ());
+    let client = CrowdfundContractClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token_contract_id = env.register_stellar_asset_contract_v2(token_admin);
+    let token_address = token_contract_id.address();
+
+    let creator = Address::generate(&env);
+    let non_creator = Address::generate(&env);
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let hard_cap: i128 = goal * 2;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &hard_cap,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
+
+    // Set auth to non-creator
+    env.mock_all_auths_allowing_non_root_auth();
+    let update_text = soroban_sdk::String::from_str(&env, "Unauthorized update");
+
+    // This should panic because non_creator is not authorized
+    client.post_update(&update_text);
+}
+
+#[test]
+#[should_panic(expected = "update text cannot be empty")]
+fn test_post_update_with_empty_text_panics() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let hard_cap: i128 = goal * 2;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &hard_cap,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
+
+    let empty_text = soroban_sdk::String::from_str(&env, "");
+    client.post_update(&empty_text); // should panic
+}
+
+#[test]
+fn test_get_updates_empty_after_initialization() {
+    let (env, client, creator, token_address, _admin) = setup_env();
+
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal: i128 = 1_000_000;
+    let hard_cap: i128 = goal * 2;
+    let min_contribution: i128 = 1_000;
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &hard_cap,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
+
+    let updates = client.get_updates();
+    assert_eq!(updates.len(), 0);
 }
 
 // ── Campaign Info Tests ────────────────────────────────────────────────────
@@ -1161,7 +1598,16 @@ fn test_get_campaign_info_initial() {
     let deadline = env.ledger().timestamp() + 3600;
     let goal: i128 = 1_000_000;
     let min_contribution: i128 = 1_000;
-    client.initialize(&creator, &token_address, &goal, &deadline, &min_contribution, &default_title(&env), &default_description(&env), &None);
+    client.initialize(
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &min_contribution,
+        &default_title(&env),
+        &default_description(&env),
+        &None,
+    );
 
     let info = client.get_campaign_info();
 


### PR DESCRIPTION
# Summary

Add DataKey::Updates storing Vec<(u64, String)> of timestamp and update text Implement pub fn post_update(env, text: String) restricted to creator only via require_auth enforcement Reject post_update if text is empty string
Automatically record env.ledger().timestamp() as the update timestamp Implement pub fn get_updates(env) -> Vec<(u64, String)> returning full ordered list of updates in chronological order Emit (campaign, update_posted) event with timestamp and text on each post Write test verifying single update is stored and retrieved correctly Write test verifying multiple updates are stored in chronological order Write test rejecting post_update call from non-creator address Write test rejecting post_update call with empty text string Write test verifying get_updates returns empty list after initialization

Also fix missing DataKey variants (WhitelistEnabled, Whitelist) and broken early_bird_deadline reference in initialize function

Closes #127 

## Description

<!-- Please provide a concise description of your changes. -->

## Related Issues
<!-- List related issues. Use "Closes #<issue-number>" to auto-close issues on merge. -->
Closes #

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update
- [x] CI / Infrastructure

## Checklist
- [x] My branch is based off `develop`, not `main`
- [x] I have run `cargo fmt --all` and the code is properly formatted
- [x] I have run `cargo clippy --all-targets -- -D warnings` with no warnings
- [x] I have run `cargo test` and all tests pass
- [x] I have added tests for any new functionality
- [x] All public functions have `///` doc comments
- [x] I have updated `CHANGELOG.md` if applicable
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) format


