### PR TITLE
feat: standardize rustdoc comments across smart contract

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -1,5 +1,4 @@
 #![no_std]
-#![allow(missing_docs)]
 #![allow(clippy::too_many_arguments)]
 
 use soroban_sdk::{
@@ -26,6 +25,7 @@ pub enum Status {
     Cancelled,
 }
 
+/// Represents a single roadmap milestone with a date and description.
 #[derive(Clone)]
 #[contracttype]
 pub struct RoadmapItem {
@@ -33,6 +33,7 @@ pub struct RoadmapItem {
     pub description: String,
 }
 
+/// Platform fee configuration: the recipient address and fee in basis points.
 #[derive(Clone)]
 #[contracttype]
 pub struct PlatformConfig {
@@ -40,7 +41,7 @@ pub struct PlatformConfig {
     pub fee_bps: u32,
 }
 
-/// Represents all storage keys used by the crowdfund contract.
+/// Snapshot of campaign funding statistics returned by [`CrowdfundContract::get_stats`].
 #[derive(Clone)]
 #[contracttype]
 pub struct CampaignStats {
@@ -52,22 +53,31 @@ pub struct CampaignStats {
     pub largest_contribution: i128,
 }
 
+/// Represents all storage keys used by the crowdfund contract.
 #[derive(Clone)]
 #[contracttype]
 pub enum DataKey {
     /// The address of the campaign creator.
     Creator,
+    /// The token contract address used for contributions.
     Token,
+    /// The funding goal in token units.
     Goal,
+    /// The campaign deadline as a Unix timestamp.
     Deadline,
+    /// The running total of tokens raised.
     TotalRaised,
+    /// Individual contribution amount keyed by contributor address.
     Contribution(Address),
+    /// List of all contributor addresses.
     Contributors,
+    /// Current campaign status.
     Status,
+    /// Minimum contribution amount.
     MinContribution,
     /// Individual pledge by address (for conditional pledges).
     Pledge(Address),
-    /// Total amount pledged but not yet claimed.
+    /// Total amount pledged but not yet collected.
     TotalPledged,
     /// Stretch goals for bonus milestones.
     StretchGoals,
@@ -81,11 +91,15 @@ pub enum DataKey {
     Pledgers,
     /// List of roadmap items with dates and descriptions.
     Roadmap,
+    /// The designated admin address (set to creator at initialization).
     Admin,
+    /// Campaign title.
     Title,
     /// Campaign description.
     Description,
+    /// Campaign social links.
     SocialLinks,
+    /// Platform fee configuration.
     PlatformConfig,
     /// Optional NFT contract used for contributor reward minting.
     NFTContract,
@@ -95,23 +109,33 @@ pub enum DataKey {
 
 use soroban_sdk::contracterror;
 
+/// Errors that can be returned by the crowdfund contract.
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(u32)]
 pub enum ContractError {
+    /// The contract has already been initialized.
     AlreadyInitialized = 1,
+    /// The campaign deadline has passed.
     CampaignEnded = 2,
+    /// The campaign deadline has not yet passed.
     CampaignStillActive = 3,
+    /// The funding goal was not reached.
     GoalNotReached = 4,
+    /// The funding goal has already been reached.
     GoalReached = 5,
+    /// An arithmetic overflow occurred.
     Overflow = 6,
 }
 
+/// Interface for an external NFT contract used to mint contributor rewards.
 #[contractclient(name = "NftContractClient")]
 pub trait NftContract {
+    /// Mints an NFT to the given address and returns the new token ID.
     fn mint(env: Env, to: Address) -> u128;
 }
 
+/// The main crowdfunding contract.
 #[contract]
 pub struct CrowdfundContract;
 
@@ -180,7 +204,7 @@ impl CrowdfundContract {
         env.storage().instance().set(&DataKey::Creator, &creator);
         env.storage().instance().set(&DataKey::Token, &token);
 
-        /// Returns the list of all contributor addresses.
+        // Returns the list of all contributor addresses.
         #[allow(dead_code)]
         pub fn contributors(env: Env) -> Vec<Address> {
             env.storage()
@@ -714,6 +738,11 @@ impl CrowdfundContract {
         );
     }
 
+    /// Add a roadmap item — only callable by the creator.
+    ///
+    /// # Arguments
+    /// * `date`        – Future Unix timestamp for the milestone.
+    /// * `description` – Non-empty description of the milestone.
     pub fn add_roadmap_item(env: Env, date: u64, description: String) {
         let creator: Address = env.storage().instance().get(&DataKey::Creator).unwrap();
         creator.require_auth();
@@ -742,6 +771,7 @@ impl CrowdfundContract {
             .publish(("campaign", "roadmap_item_added"), (date, description));
     }
 
+    /// Returns all roadmap items for the campaign.
     pub fn roadmap(env: Env) -> Vec<RoadmapItem> {
         env.storage()
             .instance()
@@ -798,6 +828,7 @@ impl CrowdfundContract {
 
         0
     }
+    /// Returns the total amount of tokens raised so far.
     pub fn total_raised(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -805,6 +836,7 @@ impl CrowdfundContract {
             .unwrap_or(0)
     }
 
+    /// Returns the campaign funding goal.
     pub fn goal(env: Env) -> i128 {
         env.storage().instance().get(&DataKey::Goal).unwrap()
     }
@@ -863,6 +895,7 @@ impl CrowdfundContract {
         env.storage().instance().get(&DataKey::Deadline).unwrap()
     }
 
+    /// Returns the contribution amount for a given contributor.
     pub fn contribution(env: Env, contributor: Address) -> i128 {
         env.storage()
             .persistent()
@@ -870,6 +903,7 @@ impl CrowdfundContract {
             .unwrap_or(0)
     }
 
+    /// Returns the minimum contribution amount required.
     pub fn min_contribution(env: Env) -> i128 {
         env.storage()
             .instance()
@@ -931,6 +965,7 @@ impl CrowdfundContract {
         }
     }
 
+    /// Returns the campaign title.
     pub fn title(env: Env) -> String {
         env.storage()
             .instance()
@@ -938,6 +973,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| String::from_str(&env, ""))
     }
 
+    /// Returns the campaign description.
     pub fn description(env: Env) -> String {
         env.storage()
             .instance()
@@ -945,6 +981,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| String::from_str(&env, ""))
     }
 
+    /// Returns the campaign social links.
     pub fn socials(env: Env) -> String {
         env.storage()
             .instance()
@@ -952,6 +989,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| String::from_str(&env, ""))
     }
 
+    /// Returns the contract version number.
     pub fn version(_env: Env) -> u32 {
         CONTRACT_VERSION
     }


### PR DESCRIPTION
Replace all plain // comments above public APIs with /// doc comments Add /// doc comments to all public functions missing them Add /// doc comments to all public struct and enum variants Format doc comments following Rust community standards with Arguments, Returns, and Errors sections where applicable Verify cargo doc --no-deps builds without warnings

Closes #156 
