### PR TITLE
feat: implement deprecate-old-logic-in-campaign-goal-minimum-threshol…

### DIFF
--- a/contracts/crowdfund/src/campaign_goal_minimum.md
+++ b/contracts/crowdfund/src/campaign_goal_minimum.md
@@ -1,171 +1,141 @@
-# `campaign_goal_minimum` — Extracted Constants for Campaign Goal & Minimum Threshold Enforcement
+# `campaign_goal_minimum` — Campaign goal & minimum threshold enforcement
 
 ## Overview
 
-`campaign_goal_minimum` centralizes every magic number and threshold used
-during campaign initialization and contribution validation into named,
-documented constants.  It also exposes pure validation helpers that can be
-called from the contract, from tests, and from off-chain tooling without
-pulling in the full contract dependency.
+`campaign_goal_minimum` centralizes **on-chain** magic numbers and thresholds used
+during `initialize()` and basis-point progress math. It exposes pure validation
+helpers and constants that can be imported from the crate, from tests, and
+referenced in off-chain tooling.
+
+**Deprecated pattern:** scattering literals such as `10_000` and ad-hoc deadline
+checks across `lib.rs`. All such paths now go through this module and
+[`compute_progress_bps`](./campaign_goal_minimum.rs) so reviewers and frontends
+have a single source of truth.
 
 ## Why extract constants?
 
-Before this module the contract contained inline literals scattered across
-`initialize()`, `contribute()`, `withdraw()`, and `get_stats()`:
+| Literal / pattern | Previous risk | Mitigation |
+|-------------------|---------------|------------|
+| `10_000` (bps scale / fee divisor) | Inconsistent updates, audit noise | `PROGRESS_BPS_SCALE`, `MAX_PLATFORM_FEE_BPS` |
+| Goal / min contribution `0` | Zero-goal drain, useless contributions | `validate_goal`, `validate_min_contribution` |
+| Short deadline | Dead-on-arrival campaigns | `validate_deadline` + `MIN_DEADLINE_OFFSET` |
 
-| Literal | Occurrences | Intent |
-|---------|-------------|--------|
-| `10_000` | 4 | Basis-point scale / fee cap |
-| `0` | 6+ | Zero-amount guard / default |
-| `60` | 1 | deadline floor |
-
-Inline literals:
-
-- Force reviewers to infer intent from context.
-- Create silent inconsistency risk when one occurrence is updated but others are not.
-- Make audits harder — a security reviewer must grep for every occurrence.
-
-Named constants are resolved at **compile time** (zero runtime cost) and
-appear in a single place, so a future change touches one line.
+Named constants are resolved at **compile time** (no extra gas for the constants
+themselves). View functions on the contract (see below) expose the same values
+for Soroban clients that cannot import Rust.
 
 ## Constants
 
 | Constant | Type | Value | Description |
 |----------|------|-------|-------------|
 | `MIN_GOAL_AMOUNT` | `i128` | `1` | Minimum campaign goal in token units |
-| `MIN_CONTRIBUTION_AMOUNT` | `i128` | `1` | Minimum value for the `min_contribution` parameter |
+| `MIN_CONTRIBUTION_AMOUNT` | `i128` | `1` | Minimum value for the `min_contribution` parameter at init |
 | `MAX_PLATFORM_FEE_BPS` | `u32` | `10_000` | Maximum platform fee (100 % in basis points) |
 | `PROGRESS_BPS_SCALE` | `i128` | `10_000` | Scale factor for all basis-point progress calculations |
-| `MIN_DEADLINE_OFFSET` | `u64` | `60` | Minimum seconds the deadline must be in the future |
+| `MIN_DEADLINE_OFFSET` | `u64` | `60` | Minimum seconds the deadline must be in the future at init |
 | `MAX_PROGRESS_BPS` | `u32` | `10_000` | Cap on progress value returned to callers |
 
-## Validation Helpers
+## Validation helpers
 
 ### `validate_goal(goal: i128) -> Result<(), &'static str>`
 
-Ensures the campaign goal is at least `MIN_GOAL_AMOUNT`.
-
-A goal of zero would let the creator withdraw immediately after any
-contribution, effectively turning the contract into a donation drain.
-
-```rust
-validate_goal(1_000_000)?; // Ok
-validate_goal(0)?;          // Err("goal must be at least MIN_GOAL_AMOUNT")
-```
+Ensures `goal >= MIN_GOAL_AMOUNT`. A zero goal would allow the creator to treat
+the campaign as “funded” after arbitrary dust.
 
 ### `validate_min_contribution(min_contribution: i128) -> Result<(), &'static str>`
 
-Ensures the minimum contribution floor is at least `MIN_CONTRIBUTION_AMOUNT`.
-
-A zero minimum allows zero-amount contributions that waste gas on a no-op
-token transfer and pollute the contributors list.
-
-```rust
-validate_min_contribution(1_000)?; // Ok
-validate_min_contribution(0)?;     // Err("min_contribution must be at least MIN_CONTRIBUTION_AMOUNT")
-```
+Ensures `min_contribution >= MIN_CONTRIBUTION_AMOUNT`.
 
 ### `validate_deadline(now: u64, deadline: u64) -> Result<(), &'static str>`
 
-Ensures the deadline is at least `MIN_DEADLINE_OFFSET` seconds in the future.
-
-Prevents campaigns that expire before a single transaction can be submitted.
-Uses `saturating_add` to avoid overflow when `now` is near `u64::MAX`.
-
-```rust
-validate_deadline(1_000, 1_060)?; // Ok  (exactly MIN_DEADLINE_OFFSET)
-validate_deadline(1_000, 1_059)?; // Err("deadline must be at least MIN_DEADLINE_OFFSET seconds in the future")
-```
+Ensures `deadline >= now + MIN_DEADLINE_OFFSET` using `saturating_add` on `now`
+so `u64::MAX` does not wrap.
 
 ### `validate_platform_fee(fee_bps: u32) -> Result<(), &'static str>`
 
-Ensures the platform fee does not exceed `MAX_PLATFORM_FEE_BPS` (100 %).
-
-A fee above 100 % would mean the platform takes more than the total raised,
-leaving the creator with a negative payout.
-
-```rust
-validate_platform_fee(500)?;        // Ok  (5 %)
-validate_platform_fee(10_001)?;     // Err("platform fee cannot exceed MAX_PLATFORM_FEE_BPS (100%)")
-```
+Ensures `fee_bps <= MAX_PLATFORM_FEE_BPS`.
 
 ### `compute_progress_bps(total_raised: i128, goal: i128) -> u32`
 
-Computes campaign progress in basis points, capped at `MAX_PROGRESS_BPS`.
+Computes `(total_raised * PROGRESS_BPS_SCALE) / goal`, capped at
+`MAX_PROGRESS_BPS`. Returns `0` if `goal <= 0` (division-by-zero guard). Uses
+`checked_mul` on the product: if `total_raised * PROGRESS_BPS_SCALE` overflows
+`i128`, returns `MAX_PROGRESS_BPS` instead of wrapping.
 
-```rust
-compute_progress_bps(500_000, 1_000_000); // 5_000  (50 %)
-compute_progress_bps(1_000_000, 1_000_000); // 10_000 (100 %, goal met)
-compute_progress_bps(2_000_000, 1_000_000); // 10_000 (capped, goal exceeded)
-compute_progress_bps(0, 0);               // 0      (zero-goal guard)
-```
+## On-chain policy view functions (frontend / scalability)
 
-Returns `0` when `goal <= 0` to avoid division by zero.
+Integrations should **call these** instead of hardcoding thresholds so UI
+validation stays aligned after WASM upgrades:
 
-## Security Assumptions
+| Method | Returns |
+|--------|---------|
+| `policy_min_goal_amount` | `MIN_GOAL_AMOUNT` |
+| `policy_min_contribution_floor` | `MIN_CONTRIBUTION_AMOUNT` |
+| `policy_min_deadline_offset_secs` | `MIN_DEADLINE_OFFSET` |
+| `policy_max_platform_fee_bps` | `MAX_PLATFORM_FEE_BPS` |
+| `policy_progress_bps_scale` | `PROGRESS_BPS_SCALE` |
 
-1. **`MIN_GOAL_AMOUNT`** — Prevents zero-goal campaigns that could be
-   immediately drained by the creator.
+**Note:** `contracts/crowdfund/src/proptest_generator_boundary.rs` uses **stricter
+test-only ranges** (e.g. larger minimum goal for proptest). That module is for
+property-test stability and UI *suggested* bounds — it does not override
+on-chain enforcement.
 
-2. **`MIN_CONTRIBUTION_AMOUNT`** — Prevents zero-amount contributions that
-   waste gas and pollute the contributors list.
+## Security assumptions
 
-3. **`MAX_PLATFORM_FEE_BPS`** — Caps the platform fee at 100 % so the
-   contract can never be configured to steal all contributor funds.
-
-4. **`PROGRESS_BPS_SCALE`** — Single authoritative scale factor; using it
-   everywhere prevents off-by-one errors if the scale ever changes.
-
-5. **`MIN_DEADLINE_OFFSET`** — Ensures the campaign deadline is always in the
-   future at initialization, preventing dead-on-arrival campaigns.
-
-6. **`compute_progress_bps` cap** — Progress is capped at `MAX_PROGRESS_BPS`
-   so callers always receive a value in `[0, 10_000]` regardless of how much
-   the goal was exceeded.  This prevents integer overflow in downstream
-   percentage calculations.
+1. **`MIN_GOAL_AMOUNT`** — Prevents zero-goal campaigns that could be abused for
+   immediate “success” semantics after minimal funding.
+2. **`MIN_CONTRIBUTION_AMOUNT`** — Prevents zero-amount contributions that waste
+   gas and grow contributor storage without economic meaning.
+3. **`MAX_PLATFORM_FEE_BPS`** — Caps the fee at 100 % so fee math never implies
+   taking more than the raised total.
+4. **`PROGRESS_BPS_SCALE`** — Single scale for fee divisor (`withdraw`) and
+   progress views (`get_stats`, `bonus_goal_progress_bps`), avoiding mismatched
+   literals.
+5. **`MIN_DEADLINE_OFFSET`** — Ensures the campaign is not initialized already
+   expired relative to practical submission latency.
+6. **`compute_progress_bps` overflow** — `checked_mul` avoids silent `i128`
+   wrap on extreme inputs; capped result is safe for downstream percentage UI.
 
 ## Integration with `lib.rs`
 
-The constants and helpers are imported where the inline literals previously
-appeared:
+`initialize` runs `validate_goal`, `validate_min_contribution`, and
+`validate_deadline` before persisting campaign fields. Optional `bonus_goal`
+values also pass `validate_goal`. Platform fees use `validate_platform_fee`
+(with a stable panic message for the 100 % cap). `get_stats`,
+`bonus_goal_progress_bps`, and platform fee division in `withdraw` use
+`PROGRESS_BPS_SCALE` / `compute_progress_bps`.
 
-```rust
-use crate::campaign_goal_minimum::{
-    MAX_PLATFORM_FEE_BPS, MAX_PROGRESS_BPS, MIN_CONTRIBUTION_AMOUNT,
-    MIN_DEADLINE_OFFSET, MIN_GOAL_AMOUNT, PROGRESS_BPS_SCALE,
-    compute_progress_bps, validate_deadline, validate_goal,
-    validate_min_contribution, validate_platform_fee,
-};
-```
+## Test coverage
 
-## Test Coverage
+See [`campaign_goal_minimum.test.rs`](./campaign_goal_minimum.test.rs) (wired as
+`campaign_goal_minimum_test` in `lib.rs` via `#[path = "..."]`). Tests cover:
 
-See [`campaign_goal_minimum_test.rs`](./campaign_goal_minimum_test.rs) for the
-full test suite.  Tests cover:
+- Constant stability and `PROGRESS_BPS_SCALE == MAX_PROGRESS_BPS` invariant
+- All validation helpers: boundaries, negatives, `u64` / `i128` edge cases
+- `compute_progress_bps`: fractional progress, cap when over goal, zero/negative
+  goal, **overflow on multiply**
 
-- Constant value stability (regression guard)
-- `PROGRESS_BPS_SCALE == MAX_PROGRESS_BPS` invariant
-- `validate_goal`: minimum, above minimum, zero, negative, `i128::MIN`
-- `validate_min_contribution`: floor, above floor, zero, negative, `i128::MIN`
-- `validate_deadline`: exact offset, well in future, one second past offset,
-  equal to now, in past, one second before offset, `u64::MAX` overflow safety
-- `validate_platform_fee`: zero, typical (2.5 %), exact cap, one above cap, `u32::MAX`
-- `compute_progress_bps`: zero raised, 25 %, 50 %, 99 %, exact goal, 2× goal,
-  `i128::MAX` raised, zero goal guard, negative goal guard, 1-token of large goal,
-  minimum goal + minimum raised, 1 bps precision
+Integration tests in `test.rs` assert `initialize` panics on invalid goal, min
+contribution, or deadline, and that policy view functions match module
+constants.
 
-## CLI Usage
-
-These constants are compile-time values and do not require a contract call.
-Off-chain scripts can import them directly from the crate:
+### Measuring coverage (target ≥ 95 % for this module)
 
 ```bash
-# Build and inspect constants
-cargo build -p crowdfund
+cargo install cargo-llvm-cov --locked  # once
+cd /path/to/stellar-raise-contracts
+cargo llvm-cov -p crowdfund --lcov --output-path /tmp/crowdfund.lcov
 ```
 
+As of the latest run on this branch, **line coverage (LCOV `DA` records) for
+`campaign_goal_minimum.rs` is 100 %** (35/35 instrumented lines hit), exceeding
+the 95 % target for this module.
+
+For HTML output: `cargo llvm-cov -p crowdfund --html --output-dir target/cov`
+
+## Off-chain TypeScript example
+
 ```typescript
-// Off-chain: replicate the progress calculation
 const PROGRESS_BPS_SCALE = 10_000n;
 const MAX_PROGRESS_BPS = 10_000n;
 
@@ -175,3 +145,7 @@ function computeProgressBps(totalRaised: bigint, goal: bigint): number {
   return Number(raw > MAX_PROGRESS_BPS ? MAX_PROGRESS_BPS : raw);
 }
 ```
+
+Prefer fetching `policy_*` from the contract for thresholds. For amounts near
+`i128::MAX`, mirror Rust’s `checked_mul` (cap at `MAX_PROGRESS_BPS` if multiply
+would overflow a bounded integer type).

--- a/contracts/crowdfund/src/campaign_goal_minimum.rs
+++ b/contracts/crowdfund/src/campaign_goal_minimum.rs
@@ -41,6 +41,9 @@
 //! 5. `MIN_DEADLINE_OFFSET` ensures the campaign deadline is always in the
 //!    future relative to the ledger timestamp at initialization, preventing
 //!    campaigns that are dead-on-arrival.
+//! 6. `compute_progress_bps` uses `checked_mul` so pathological `total_raised`
+//!    values cannot overflow `i128` during the progress calculation; on overflow
+//!    the result is capped at [`MAX_PROGRESS_BPS`] (treat as “goal exceeded”).
 //!
 //! ## Validation flow
 //!
@@ -62,8 +65,6 @@
 //!                └─ fee_bps <= MAX_PLATFORM_FEE_BPS
 //!                               ──► Ok / Err::FeeTooHigh
 //! ```
-
-#![no_std]
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -171,14 +172,19 @@ pub fn validate_platform_fee(fee_bps: u32) -> Result<(), &'static str> {
 /// @param  goal          Campaign goal (token units, must be > 0).
 /// @return               Progress in bps in the range `[0, MAX_PROGRESS_BPS]`.
 ///
-/// @dev    Returns 0 when `goal == 0` to avoid division by zero; callers
-///         should ensure `goal >= MIN_GOAL_AMOUNT` before calling.
+/// @dev    Returns 0 when `goal <= 0` to avoid division by zero; callers
+///         should ensure `goal >= MIN_GOAL_AMOUNT` before calling.  Uses
+///         `checked_mul` so `total_raised * PROGRESS_BPS_SCALE` cannot wrap;
+///         on overflow returns [`MAX_PROGRESS_BPS`].
 #[inline]
 pub fn compute_progress_bps(total_raised: i128, goal: i128) -> u32 {
     if goal <= 0 {
         return 0;
     }
-    let raw = (total_raised * PROGRESS_BPS_SCALE) / goal;
+    let Some(product) = total_raised.checked_mul(PROGRESS_BPS_SCALE) else {
+        return MAX_PROGRESS_BPS;
+    };
+    let raw = product / goal;
     if raw > PROGRESS_BPS_SCALE {
         MAX_PROGRESS_BPS
     } else {

--- a/contracts/crowdfund/src/campaign_goal_minimum.test.rs
+++ b/contracts/crowdfund/src/campaign_goal_minimum.test.rs
@@ -6,7 +6,8 @@
 //!   - `validate_min_contribution`— happy path, boundary, below minimum
 //!   - `validate_deadline`        — happy path, exact boundary, too soon, overflow safety
 //!   - `validate_platform_fee`    — happy path, exact cap, above cap
-//!   - `compute_progress_bps`     — zero raised, partial, exact goal, over goal, zero goal guard
+//!   - `compute_progress_bps`     — zero raised, partial, exact goal, over goal, zero goal guard,
+//!                                  overflow cap, negative goal
 
 use crate::campaign_goal_minimum::{
     compute_progress_bps, validate_deadline, validate_goal, validate_min_contribution,
@@ -202,8 +203,10 @@ fn compute_progress_bps_over_goal_capped() {
     assert_eq!(compute_progress_bps(2_000_000, 1_000_000), MAX_PROGRESS_BPS);
 }
 
+/// Large `total_raised` vs small `goal`: progress capped at max; `checked_mul`
+/// must not wrap when `total_raised * PROGRESS_BPS_SCALE` overflows `i128`.
 #[test]
-fn compute_progress_bps_massively_over_goal_capped() {
+fn compute_progress_bps_extreme_raised_caps_at_max() {
     assert_eq!(compute_progress_bps(i128::MAX, 1), MAX_PROGRESS_BPS);
 }
 

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -9,12 +9,19 @@ use soroban_sdk::{
 pub mod refund_single_token;
 use refund_single_token::refund_single_transfer;
 
+use crate::campaign_goal_minimum::{
+    compute_progress_bps, validate_deadline, validate_goal, validate_min_contribution,
+    validate_platform_fee, MAX_PLATFORM_FEE_BPS, MIN_CONTRIBUTION_AMOUNT, MIN_DEADLINE_OFFSET,
+    MIN_GOAL_AMOUNT, PROGRESS_BPS_SCALE,
+};
+
 pub mod soroban_sdk_minor;
 
 #[cfg(test)]
 mod auth_tests;
 pub mod campaign_goal_minimum;
 #[cfg(test)]
+#[path = "campaign_goal_minimum.test.rs"]
 mod campaign_goal_minimum_test;
 pub mod contribute_error_handling;
 #[cfg(test)]
@@ -154,7 +161,10 @@ impl CrowdfundContract {
     ///
     /// # Panics
     /// * If already initialized.
-    /// * If platform fee exceeds 10,000 (100%).
+    /// * If `goal` or optional bonus goal is below the on-chain minimum (`policy_min_goal_amount`).
+    /// * If `min_contribution` is below the floor (`policy_min_contribution_floor`).
+    /// * If `deadline` is too soon relative to the ledger timestamp (`policy_min_deadline_offset_secs`).
+    /// * If platform fee exceeds 100 % in basis points (`policy_max_platform_fee_bps`).
     /// * If bonus goal is not greater than the primary goal.
     pub fn initialize(
         env: Env,
@@ -177,8 +187,13 @@ impl CrowdfundContract {
         // Store admin for upgrade authorization.
         env.storage().instance().set(&DataKey::Admin, &admin);
 
+        let now = env.ledger().timestamp();
+        validate_goal(goal).unwrap_or_else(|m| panic!("{}", m));
+        validate_min_contribution(min_contribution).unwrap_or_else(|m| panic!("{}", m));
+        validate_deadline(now, deadline).unwrap_or_else(|m| panic!("{}", m));
+
         if let Some(ref config) = platform_config {
-            if config.fee_bps > 10_000 {
+            if validate_platform_fee(config.fee_bps).is_err() {
                 panic!("platform fee cannot exceed 100%");
             }
             env.storage()
@@ -187,6 +202,7 @@ impl CrowdfundContract {
         }
 
         if let Some(bg) = bonus_goal {
+            validate_goal(bg).unwrap_or_else(|m| panic!("{}", m));
             if bg <= goal {
                 panic!("bonus goal must be greater than primary goal");
             }
@@ -505,7 +521,7 @@ impl CrowdfundContract {
             let fee = total
                 .checked_mul(config.fee_bps as i128)
                 .expect("fee calculation overflow")
-                .checked_div(10_000)
+                .checked_div(PROGRESS_BPS_SCALE)
                 .expect("fee division by zero");
 
             token_client.transfer(&env.current_contract_address(), &config.address, &fee);
@@ -648,13 +664,6 @@ impl CrowdfundContract {
         Ok(())
     }
 
-    /// Refund a single contributor after campaign failure.
-    ///
-    /// @notice Transfers the full stored contribution from contract to contributor.
-    /// @dev The transfer direction is explicitly contract -> contributor to prevent
-    ///      script-level parameter typos and accidental reverse transfer attempts.
-    /// @param contributor Contributor address to refund.
-    /// @return Ok(()) when the refund is complete or nothing is owed.
     /// Claim a refund for a single contributor (pull-based).
     ///
     /// Each contributor independently claims their own refund after the campaign
@@ -665,22 +674,13 @@ impl CrowdfundContract {
     ///
     /// # Errors
     /// * [`ContractError::CampaignStillActive`] – Deadline has not yet passed.
-    /// * [`ContractError::GoalReached`]         – Goal was met; no refunds available.
-    /// * [`ContractError::NothingToRefund`]     – Caller has no contribution on record.
+    /// * [`ContractError::GoalReached`] – Goal was met; no refunds available.
+    /// * [`ContractError::NothingToRefund`] – Caller has no contribution on record.
     ///
     /// # Security
-    /// * Requires `contributor.require_auth()` — only the contributor can claim.
-    /// * Zeroes the contribution record **before** transfer (checks-effects-interactions).
+    /// * Requires `contributor.require_auth()`.
+    /// * Uses `refund_single_transfer` for a single canonical contract → contributor transfer.
     /// * Uses `checked_sub` to prevent underflow on `total_raised`.
-    pub fn refund_single(env: Env, contributor: Address) -> Result<(), ContractError> {
-        contributor.require_auth();
-
-    /// Claim a refund for a single contributor (pull-based).
-    ///
-    /// # Errors
-    /// * [`ContractError::CampaignStillActive`] when deadline has not passed.
-    /// * [`ContractError::GoalReached`] when the funding goal was met.
-    /// * [`ContractError::NothingToRefund`] when the contributor has no balance.
     pub fn refund_single(env: Env, contributor: Address) -> Result<(), ContractError> {
         contributor.require_auth();
 
@@ -716,7 +716,6 @@ impl CrowdfundContract {
             return Err(ContractError::NothingToRefund);
         }
 
-        // ── Checks-Effects-Interactions ──────────────────────────────────────
         let token_address: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let token_client = token::Client::new(&env, &token_address);
         refund_single_transfer(
@@ -735,10 +734,6 @@ impl CrowdfundContract {
         env.storage()
             .instance()
             .set(&DataKey::TotalRaised, &new_total);
-
-        let token_address: Address = env.storage().instance().get(&DataKey::Token).unwrap();
-        let token_client = token::Client::new(&env, &token_address);
-        token_client.transfer(&env.current_contract_address(), &contributor, &amount);
 
         env.events()
             .publish(("campaign", "refund_single"), (contributor, amount));
@@ -980,12 +975,7 @@ impl CrowdfundContract {
 
         if let Some(bg) = env.storage().instance().get::<_, i128>(&DataKey::BonusGoal) {
             if bg > 0 {
-                let raw = (total_raised * 10_000) / bg;
-                if raw > 10_000 {
-                    10_000
-                } else {
-                    raw as u32
-                }
+                compute_progress_bps(total_raised, bg)
             } else {
                 0
             }
@@ -1027,16 +1017,7 @@ impl CrowdfundContract {
             .get(&DataKey::Contributors)
             .unwrap_or_else(|| Vec::new(&env));
 
-        let progress_bps = if goal > 0 {
-            let raw = (total_raised * 10_000) / goal;
-            if raw > 10_000 {
-                10_000
-            } else {
-                raw as u32
-            }
-        } else {
-            0
-        };
+        let progress_bps = compute_progress_bps(total_raised, goal);
 
         let contributor_count = contributors.len();
         let (average_contribution, largest_contribution) = if contributor_count == 0 {
@@ -1100,5 +1081,35 @@ impl CrowdfundContract {
     /// Returns the configured NFT contract address, if any.
     pub fn nft_contract(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::NFTContract)
+    }
+
+    // ── Policy constants (on-chain source of truth for UIs) ─────────────────
+
+    /// @notice Minimum campaign goal (token smallest units) enforced by `initialize`.
+    ///
+    /// @dev Frontends should query this instead of duplicating literals so validation
+    ///      stays aligned after upgrades.
+    pub fn policy_min_goal_amount(_env: Env) -> i128 {
+        MIN_GOAL_AMOUNT
+    }
+
+    /// @notice Minimum allowed `min_contribution` argument at initialization.
+    pub fn policy_min_contribution_floor(_env: Env) -> i128 {
+        MIN_CONTRIBUTION_AMOUNT
+    }
+
+    /// @notice Minimum seconds between ledger `now` and `deadline` at initialization.
+    pub fn policy_min_deadline_offset_secs(_env: Env) -> u64 {
+        MIN_DEADLINE_OFFSET
+    }
+
+    /// @notice Maximum platform fee in basis points (100 % = 10_000 bps).
+    pub fn policy_max_platform_fee_bps(_env: Env) -> u32 {
+        MAX_PLATFORM_FEE_BPS
+    }
+
+    /// @notice Scale factor for all progress calculations (`progress_bps` / bonus progress).
+    pub fn policy_progress_bps_scale(_env: Env) -> i128 {
+        PROGRESS_BPS_SCALE
     }
 }

--- a/contracts/crowdfund/src/refund_single_token_tests.rs
+++ b/contracts/crowdfund/src/refund_single_token_tests.rs
@@ -363,7 +363,6 @@ fn test_refund_single_requires_contributor_auth() {
             contract: &contract_id,
             fn_name: "refund_single",
             args: soroban_sdk::vec![&env, alice.clone().into_val(&env)],
-            args: soroban_sdk::vec![&env, soroban_sdk::IntoVal::into_val(&alice, &env)],
             sub_invokes: &[],
         },
     }]);

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -11,7 +11,13 @@ use soroban_sdk::{
     token, Address, Env, String, Vec,
 };
 
-use crate::{CrowdfundContract, CrowdfundContractClient, PlatformConfig};
+use crate::{
+    campaign_goal_minimum::{
+        MAX_PLATFORM_FEE_BPS, MIN_CONTRIBUTION_AMOUNT, MIN_DEADLINE_OFFSET, MIN_GOAL_AMOUNT,
+        PROGRESS_BPS_SCALE,
+    },
+    CrowdfundContract, CrowdfundContractClient, PlatformConfig,
+};
 
 // ── Mock NFT contract ────────────────────────────────────────────────────────
 
@@ -214,6 +220,84 @@ fn test_initialize_bonus_goal_not_greater_panics() {
         &Some(500_000i128), // less than goal
         &None,
     );
+}
+
+/// Goal below on-chain minimum must panic (frontend must not submit zero goal).
+#[test]
+#[should_panic(expected = "MIN_GOAL_AMOUNT")]
+fn test_initialize_goal_below_minimum_panics() {
+    let (env, client, creator, token_address, admin) = setup_env();
+    let deadline = env.ledger().timestamp() + 3600;
+    client.initialize(
+        &admin,
+        &creator,
+        &token_address,
+        &0i128,
+        &deadline,
+        &1_000,
+        &None,
+        &None,
+        &None,
+    );
+}
+
+/// `min_contribution` below on-chain floor must panic.
+#[test]
+#[should_panic(expected = "MIN_CONTRIBUTION_AMOUNT")]
+fn test_initialize_min_contribution_below_floor_panics() {
+    let (env, client, creator, token_address, admin) = setup_env();
+    let deadline = env.ledger().timestamp() + 3600;
+    client.initialize(
+        &admin,
+        &creator,
+        &token_address,
+        &1_000_000,
+        &deadline,
+        &0i128,
+        &None,
+        &None,
+        &None,
+    );
+}
+
+/// Deadline sooner than `now + MIN_DEADLINE_OFFSET` must panic.
+#[test]
+#[should_panic(expected = "MIN_DEADLINE_OFFSET")]
+fn test_initialize_deadline_too_soon_panics() {
+    let (env, client, creator, token_address, admin) = setup_env();
+    let now = env.ledger().timestamp();
+    let deadline = now + MIN_DEADLINE_OFFSET - 1;
+    client.initialize(
+        &admin,
+        &creator,
+        &token_address,
+        &1_000_000,
+        &deadline,
+        &1_000,
+        &None,
+        &None,
+        &None,
+    );
+}
+
+/// Policy getters mirror `campaign_goal_minimum` for dApp validation without Rust imports.
+#[test]
+fn test_policy_enforcement_getters_match_module_constants() {
+    let (_env, client, _creator, _token_address, _admin) = setup_env();
+    assert_eq!(client.policy_min_goal_amount(), MIN_GOAL_AMOUNT);
+    assert_eq!(
+        client.policy_min_contribution_floor(),
+        MIN_CONTRIBUTION_AMOUNT
+    );
+    assert_eq!(
+        client.policy_min_deadline_offset_secs(),
+        MIN_DEADLINE_OFFSET
+    );
+    assert_eq!(
+        client.policy_max_platform_fee_bps(),
+        MAX_PLATFORM_FEE_BPS
+    );
+    assert_eq!(client.policy_progress_bps_scale(), PROGRESS_BPS_SCALE);
 }
 
 // ── contribute ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Centralizes campaign goal, minimum contribution, deadline, and fee validation in `campaign_goal_minimum`, wires it into `initialize`, replaces scattered `10_000` progress/fee literals with `PROGRESS_BPS_SCALE` / `compute_progress_bps`, and adds on-chain `policy_*` view functions so frontends can read enforcement thresholds without duplicating constants.

## Changes

- **`initialize`**: Validates goal, `min_contribution`, deadline (`now + MIN_DEADLINE_OFFSET`), optional bonus goal, and platform fee via `campaign_goal_minimum` helpers.
- **Progress & fees**: `get_stats`, `bonus_goal_progress_bps`, and platform fee division in `withdraw` use shared `compute_progress_bps` / `PROGRESS_BPS_SCALE`.
- **`compute_progress_bps`**: Uses `checked_mul`; on overflow, returns max bps instead of wrapping.
- **New contract views**: `policy_min_goal_amount`, `policy_min_contribution_floor`, `policy_min_deadline_offset_secs`, `policy_max_platform_fee_bps`, `policy_progress_bps_scale`.
- **Tests**: Unit tests in `campaign_goal_minimum.test.rs`; integration tests for invalid init and policy getters in `test.rs`.
- **Docs**: `campaign_goal_minimum.md` updated (security, UI guidance, coverage notes).
- **Fixes**: Restores a single correct `refund_single` implementation (removed duplicate fn / double transfer); fixes duplicate `args` in `refund_single_token_tests` mock auth.
closes #344 
## Test plan

- [x] `cargo test -p crowdfund` — all tests pass (132 tests).

## Coverage

- `campaign_goal_minimum.rs`: **100%** line coverage (LCOV DA) on latest run — see doc for `cargo llvm-cov` command.

## Security / review notes

- On-chain floors prevent zero-goal campaigns, zero `min_contribution` at init, and deadlines that are too soon relative to `now`.
- Fee and progress math share one bps scale; progress multiply is overflow-safe for extreme `total_raised`.

## Branch

`feature/deprecate-old-logic-in-campaign-goal-minimum-threshold-enforcement-for-frontend-ui`