### PR TITLE
feat: implement robust campaign lifecycle state management

### DIFF
--- a/contracts/crowdfund/src/auth_tests.rs
+++ b/contracts/crowdfund/src/auth_tests.rs
@@ -87,6 +87,7 @@ fn test_withdraw_only_creator_can_withdraw() {
     client.contribute(&contributor, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize();
     client.withdraw();
 
     assert_eq!(client.total_raised(), 0);

--- a/contracts/crowdfund/src/contribute_error_handling_tests.rs
+++ b/contracts/crowdfund/src/contribute_error_handling_tests.rs
@@ -138,6 +138,7 @@ fn contribute_to_successful_campaign_returns_not_active() {
     // Advance past deadline and withdraw
     env.ledger()
         .set_timestamp(env.ledger().timestamp() + DEADLINE_OFFSET);
+    client.finalize();
     client.withdraw();
     // Now try to contribute
     let result = client.try_contribute(&contributor, &MIN);

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -57,12 +57,17 @@ pub const MAX_NFT_MINT_BATCH: u32 = 50;
 // ── Data Types ──────────────────────────────────────────────────────────────
 
 /// Represents the campaign status.
+///
+/// Transitions:
+///   `Active` → `Succeeded`  (via `finalize` when deadline passed and goal met)
+///   `Active` → `Expired`    (via `finalize` when deadline passed and goal not met)
+///   `Active` → `Cancelled`  (via `cancel`)
 #[derive(Clone, PartialEq)]
 #[contracttype]
 pub enum Status {
     Active,
-    Successful,
-    Refunded,
+    Succeeded,
+    Expired,
     Cancelled,
 }
 
@@ -536,19 +541,23 @@ impl CrowdfundContract {
         Ok(())
     }
 
-    /// Withdraw raised funds — only callable by the creator after the
-    /// deadline, and only if the goal has been met.
+    /// Finalize the campaign by transitioning it from `Active` to either
+    /// `Succeeded` or `Expired` based on the deadline and total raised.
     ///
-    /// If a platform fee is configured, deducts the fee and transfers it to
-    /// the platform address, then sends the remainder to the creator.
-    pub fn withdraw(env: Env) -> Result<(), ContractError> {
+    /// - `Active → Succeeded`: deadline has passed **and** goal was met.
+    /// - `Active → Expired`:   deadline has passed **and** goal was not met.
+    ///
+    /// Anyone may call this function — it is permissionless and idempotent
+    /// in the sense that it will panic if the campaign is not `Active`.
+    ///
+    /// # Errors
+    /// * Panics if the campaign is not `Active`.
+    /// * Returns `ContractError::CampaignStillActive` if the deadline has not passed.
+    pub fn finalize(env: Env) -> Result<Status, ContractError> {
         let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
         if status != Status::Active {
             panic!("campaign is not active");
         }
-
-        let creator: Address = env.storage().instance().get(&DataKey::Creator).unwrap();
-        creator.require_auth();
 
         let deadline: u64 = env.storage().instance().get(&DataKey::Deadline).unwrap();
         if env.ledger().timestamp() <= deadline {
@@ -556,11 +565,45 @@ impl CrowdfundContract {
         }
 
         let goal: i128 = env.storage().instance().get(&DataKey::Goal).unwrap();
-        let total: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap();
-        if total < goal {
-            return Err(ContractError::GoalNotReached);
+        let total: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap_or(0);
+
+        let new_status = if total >= goal {
+            Status::Succeeded
+        } else {
+            Status::Expired
+        };
+
+        env.storage().instance().set(&DataKey::Status, &new_status);
+        env.events().publish(("campaign", "finalized"), new_status.clone());
+
+        Ok(new_status)
+    }
+
+    /// Returns the current stored campaign status.
+    pub fn status(env: Env) -> Status {
+        env.storage().instance().get(&DataKey::Status).unwrap()
+    }
+
+    /// Withdraw raised funds — only callable by the creator after the campaign
+    /// has been finalized as `Succeeded`.
+    ///
+    /// Call `finalize()` first to transition the campaign from `Active` to
+    /// `Succeeded` (deadline passed + goal met). This explicit two-step design
+    /// prevents "state bleeding" where a creator could withdraw while the
+    /// campaign is still technically active.
+    ///
+    /// If a platform fee is configured, deducts the fee and transfers it to
+    /// the platform address, then sends the remainder to the creator.
+    pub fn withdraw(env: Env) -> Result<(), ContractError> {
+        let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
+        if status != Status::Succeeded {
+            panic!("campaign must be in Succeeded state to withdraw");
         }
 
+        let creator: Address = env.storage().instance().get(&DataKey::Creator).unwrap();
+        creator.require_auth();
+
+        let total: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap();
         let token_address: Address = env.storage().instance().get(&DataKey::Token).unwrap();
         let token_client = token::Client::new(&env, &token_address);
 
@@ -585,9 +628,6 @@ impl CrowdfundContract {
         token_client.transfer(&env.current_contract_address(), &creator, &creator_payout);
 
         env.storage().instance().set(&DataKey::TotalRaised, &0i128);
-        env.storage()
-            .instance()
-            .set(&DataKey::Status, &Status::Successful);
 
         // Bounded NFT minting: process at most MAX_NFT_MINT_BATCH contributors
         // per withdraw() call to cap event emission and gas consumption.
@@ -661,19 +701,8 @@ impl CrowdfundContract {
     #[allow(deprecated)]
     pub fn refund(env: Env) -> Result<(), ContractError> {
         let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
-        if status != Status::Active {
-            panic!("campaign is not active");
-        }
-
-        let deadline: u64 = env.storage().instance().get(&DataKey::Deadline).unwrap();
-        if env.ledger().timestamp() <= deadline {
-            return Err(ContractError::CampaignStillActive);
-        }
-
-        let goal: i128 = env.storage().instance().get(&DataKey::Goal).unwrap();
-        let total: i128 = env.storage().instance().get(&DataKey::TotalRaised).unwrap();
-        if total >= goal {
-            return Err(ContractError::GoalReached);
+        if status != Status::Expired {
+            panic!("campaign must be in Expired state to refund");
         }
 
         let token_address: Address = env.storage().instance().get(&DataKey::Token).unwrap();
@@ -707,9 +736,6 @@ impl CrowdfundContract {
         }
 
         env.storage().instance().set(&DataKey::TotalRaised, &0i128);
-        env.storage()
-            .instance()
-            .set(&DataKey::Status, &Status::Refunded);
 
         Ok(())
     }

--- a/contracts/crowdfund/src/refund_single_token.rs
+++ b/contracts/crowdfund/src/refund_single_token.rs
@@ -28,6 +28,32 @@ use soroban_sdk::{token, Address, Env};
 
 use crate::{ContractError, DataKey, Status};
 
+// ── Storage helpers ───────────────────────────────────────────────────────────
+
+/// Read the stored contribution amount for `contributor` (0 if absent).
+pub fn get_contribution(env: &Env, contributor: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Contribution(contributor.clone()))
+        .unwrap_or(0)
+}
+
+/// Low-level refund helper: transfer `amount` from contract to `contributor`
+/// and zero the contribution record. Returns the amount transferred.
+///
+/// Does **not** check campaign status or auth — callers are responsible.
+pub fn refund_single(env: &Env, token_address: &Address, contributor: &Address) -> i128 {
+    let amount = get_contribution(env, contributor);
+    if amount > 0 {
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contribution(contributor.clone()), &0i128);
+        let token_client = token::Client::new(env, token_address);
+        refund_single_transfer(&token_client, &env.current_contract_address(), contributor, amount);
+    }
+    amount
+}
+
 // ── Transfer primitive ────────────────────────────────────────────────────────
 
 /// Transfer `amount` tokens from the contract to `contributor`.
@@ -60,34 +86,18 @@ pub fn refund_single_transfer(
 /// @return `Ok(amount)` when the refund is valid, `Err(ContractError)` otherwise.
 ///
 /// # Errors
-/// * `ContractError::CampaignStillActive` — deadline has not yet passed.
-/// * `ContractError::GoalReached`         — goal was met; no refunds available.
+/// * `ContractError::CampaignStillActive` — campaign has not been finalized as `Expired`.
 /// * `ContractError::NothingToRefund`     — contributor has no balance on record.
 ///
 /// # Panics
-/// * `"campaign is not active"` when status is `Successful` or `Cancelled`.
+/// * `"campaign must be in Expired state to refund"` when status is not `Expired`.
 pub fn validate_refund_preconditions(
     env: &Env,
     contributor: &Address,
 ) -> Result<i128, ContractError> {
     let status: Status = env.storage().instance().get(&DataKey::Status).unwrap();
-    if status == Status::Successful || status == Status::Cancelled {
-        panic!("campaign is not active");
-    }
-
-    let deadline: u64 = env.storage().instance().get(&DataKey::Deadline).unwrap();
-    if env.ledger().timestamp() <= deadline {
-        return Err(ContractError::CampaignStillActive);
-    }
-
-    let goal: i128 = env.storage().instance().get(&DataKey::Goal).unwrap();
-    let total: i128 = env
-        .storage()
-        .instance()
-        .get(&DataKey::TotalRaised)
-        .unwrap_or(0);
-    if total >= goal {
-        return Err(ContractError::GoalReached);
+    if status != Status::Expired {
+        panic!("campaign must be in Expired state to refund");
     }
 
     let amount: i128 = env

--- a/contracts/crowdfund/src/refund_single_token.test.rs
+++ b/contracts/crowdfund/src/refund_single_token.test.rs
@@ -66,6 +66,7 @@ fn test_validate_returns_amount_on_success() {
     client.contribute(&alice, &50_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     let result = env.as_contract(&client.address, || {
         validate_refund_preconditions(&env, &alice)
@@ -73,8 +74,9 @@ fn test_validate_returns_amount_on_success() {
     assert_eq!(result, Ok(50_000));
 }
 
-/// @test Returns CampaignStillActive when deadline has not passed.
+/// @test Panics when campaign is still Active (deadline not passed, not finalized).
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_validate_before_deadline_returns_campaign_still_active() {
     let (env, client, creator, token) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -84,15 +86,15 @@ fn test_validate_before_deadline_returns_campaign_still_active() {
     mint(&env, &token, &alice, 50_000);
     client.contribute(&alice, &50_000);
 
-    // Do NOT advance past deadline
-    let result = env.as_contract(&client.address, || {
-        validate_refund_preconditions(&env, &alice)
+    // Do NOT advance past deadline — campaign stays Active
+    env.as_contract(&client.address, || {
+        validate_refund_preconditions(&env, &alice).unwrap();
     });
-    assert_eq!(result, Err(ContractError::CampaignStillActive));
 }
 
-/// @test Returns CampaignStillActive when called exactly at the deadline.
+/// @test Panics when campaign is Active at the deadline boundary.
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_validate_at_deadline_boundary_returns_campaign_still_active() {
     let (env, client, creator, token) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -102,15 +104,15 @@ fn test_validate_at_deadline_boundary_returns_campaign_still_active() {
     mint(&env, &token, &alice, 50_000);
     client.contribute(&alice, &50_000);
 
-    env.ledger().set_timestamp(deadline); // exactly at, not past
-    let result = env.as_contract(&client.address, || {
-        validate_refund_preconditions(&env, &alice)
+    env.ledger().set_timestamp(deadline); // exactly at, not past — finalize would fail
+    env.as_contract(&client.address, || {
+        validate_refund_preconditions(&env, &alice).unwrap();
     });
-    assert_eq!(result, Err(ContractError::CampaignStillActive));
 }
 
-/// @test Returns GoalReached when total_raised >= goal.
+/// @test Panics when campaign is Succeeded (goal was met).
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_validate_goal_reached_returns_goal_reached() {
     let (env, client, creator, token) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -122,14 +124,16 @@ fn test_validate_goal_reached_returns_goal_reached() {
     client.contribute(&alice, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
-    let result = env.as_contract(&client.address, || {
-        validate_refund_preconditions(&env, &alice)
+    client.finalize(); // Active → Succeeded
+
+    env.as_contract(&client.address, || {
+        validate_refund_preconditions(&env, &alice).unwrap();
     });
-    assert_eq!(result, Err(ContractError::GoalReached));
 }
 
-/// @test Returns GoalReached when total_raised exceeds goal.
+/// @test Panics when campaign is Succeeded (goal exceeded).
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_validate_goal_exceeded_returns_goal_reached() {
     let (env, client, creator, token) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -141,10 +145,11 @@ fn test_validate_goal_exceeded_returns_goal_reached() {
     client.contribute(&alice, &(goal + 50_000));
 
     env.ledger().set_timestamp(deadline + 1);
-    let result = env.as_contract(&client.address, || {
-        validate_refund_preconditions(&env, &alice)
+    client.finalize(); // Active → Succeeded
+
+    env.as_contract(&client.address, || {
+        validate_refund_preconditions(&env, &alice).unwrap();
     });
-    assert_eq!(result, Err(ContractError::GoalReached));
 }
 
 /// @test Returns NothingToRefund for an address with no contribution.
@@ -156,6 +161,7 @@ fn test_validate_no_contribution_returns_nothing_to_refund() {
 
     let stranger = Address::generate(&env);
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     let result = env.as_contract(&client.address, || {
         validate_refund_preconditions(&env, &stranger)
@@ -175,6 +181,7 @@ fn test_validate_after_refund_returns_nothing_to_refund() {
     client.contribute(&alice, &10_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     // First refund via the contract method (zeroes storage)
     client.refund_single(&alice);
@@ -185,9 +192,9 @@ fn test_validate_after_refund_returns_nothing_to_refund() {
     assert_eq!(result, Err(ContractError::NothingToRefund));
 }
 
-/// @test Panics with "campaign is not active" on a Successful campaign.
+/// @test Panics with "campaign must be in Expired state to refund" on a Succeeded campaign.
 #[test]
-#[should_panic(expected = "campaign is not active")]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_validate_panics_on_successful_campaign() {
     let (env, client, creator, token) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -199,16 +206,17 @@ fn test_validate_panics_on_successful_campaign() {
     client.contribute(&alice, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
-    client.withdraw(); // → Successful
+    client.finalize(); // → Succeeded
+    client.withdraw();
 
     env.as_contract(&client.address, || {
         validate_refund_preconditions(&env, &alice).unwrap();
     });
 }
 
-/// @test Panics with "campaign is not active" on a Cancelled campaign.
+/// @test Panics with "campaign must be in Expired state to refund" on a Cancelled campaign.
 #[test]
-#[should_panic(expected = "campaign is not active")]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_validate_panics_on_cancelled_campaign() {
     let (env, client, creator, token) = setup();
     let deadline = env.ledger().timestamp() + 3_600;

--- a/contracts/crowdfund/src/refund_single_token_test.rs
+++ b/contracts/crowdfund/src/refund_single_token_test.rs
@@ -316,6 +316,7 @@ mod refund_single_tests {
 
         let token_client = token::Client::new(&env, &token_address);
 
+        client.finalize(); // Active → Expired
         client.refund();
 
         // All contributors must have their tokens back
@@ -327,7 +328,7 @@ mod refund_single_tests {
 
     /// @test Bulk refund() cannot be called twice (status guard).
     #[test]
-    #[should_panic(expected = "campaign is not active")]
+    #[should_panic(expected = "campaign must be in Expired state to refund")]
     fn test_bulk_refund_cannot_be_called_twice() {
         let (env, client, creator, token_address, admin) = setup();
         let deadline = env.ledger().timestamp() + 3_600;
@@ -338,8 +339,9 @@ mod refund_single_tests {
         client.contribute(&alice, &100_000);
 
         env.ledger().set_timestamp(deadline + 1);
+        client.finalize(); // Active → Expired
         client.refund();
-        client.refund(); // must panic — status is Refunded
+        client.refund(); // must panic — already Expired, not Active
     }
 
     /// @test refund() is blocked while the campaign is still active (before deadline).
@@ -353,12 +355,12 @@ mod refund_single_tests {
         mint(&env, &token_address, &alice, 100_000);
         client.contribute(&alice, &100_000);
 
-        // Do NOT advance past deadline
+        // Do NOT advance past deadline — campaign is Active, refund panics
         let result = client.try_refund();
         assert!(result.is_err());
     }
 
-    /// @test refund() is blocked when the goal has been reached.
+    /// @test refund() is blocked when the goal has been reached (Succeeded state).
     #[test]
     fn test_refund_blocked_when_goal_reached() {
         let (env, client, creator, token_address, admin) = setup();
@@ -371,9 +373,10 @@ mod refund_single_tests {
         client.contribute(&alice, &goal);
 
         env.ledger().set_timestamp(deadline + 1);
+        client.finalize(); // Active → Succeeded
 
         let result = client.try_refund();
-        assert!(result.is_err()); // GoalReached error
+        assert!(result.is_err()); // panics — not Expired
     }
 
     // ── get_contribution helper ───────────────────────────────────────────────

--- a/contracts/crowdfund/src/refund_single_token_tests.rs
+++ b/contracts/crowdfund/src/refund_single_token_tests.rs
@@ -69,8 +69,8 @@ fn init(
 
 // ── Happy path ────────────────────────────────────────────────────────────────
 
-/// A single contributor can claim their full refund after the deadline
-/// when the goal was not met.
+/// A single contributor can claim their full refund after the campaign
+/// has been finalized as Expired (deadline passed, goal not met).
 #[test]
 fn test_refund_single_basic() {
     let (env, client, creator, token, _admin) = setup();
@@ -82,6 +82,7 @@ fn test_refund_single_basic() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund_single(&alice);
 
     let tc = token::Client::new(&env, &token);
@@ -108,6 +109,7 @@ fn test_refund_single_multiple_contributors() {
     client.contribute(&carol, &100_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     client.refund_single(&alice);
     client.refund_single(&bob);
@@ -135,6 +137,7 @@ fn test_refund_single_decrements_total_raised_incrementally() {
     client.contribute(&bob, &200_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     assert_eq!(client.total_raised(), 600_000);
     client.refund_single(&alice);
@@ -159,6 +162,7 @@ fn test_refund_single_accumulated_contributions() {
     assert_eq!(client.contribution(&alice), 900_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund_single(&alice);
 
     let tc = token::Client::new(&env, &token);
@@ -181,6 +185,7 @@ fn test_refund_single_double_claim_returns_nothing_to_refund() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund_single(&alice);
 
     let result = client.try_refund_single(&alice);
@@ -198,6 +203,7 @@ fn test_refund_single_no_contribution_returns_nothing_to_refund() {
 
     let stranger = Address::generate(&env);
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     let result = client.try_refund_single(&stranger);
     assert_eq!(result.unwrap_err().unwrap(), ContractError::NothingToRefund);
@@ -205,8 +211,9 @@ fn test_refund_single_no_contribution_returns_nothing_to_refund() {
 
 // ── Deadline guard ────────────────────────────────────────────────────────────
 
-/// Calling `refund_single` before the deadline returns `CampaignStillActive`.
+/// Calling `refund_single` before finalize (campaign still Active) panics.
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_single_before_deadline_returns_campaign_still_active() {
     let (env, client, creator, token, _admin) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -216,16 +223,13 @@ fn test_refund_single_before_deadline_returns_campaign_still_active() {
     mint(&env, &token, &alice, 500_000);
     client.contribute(&alice, &500_000);
 
-    // Do NOT advance time past deadline.
-    let result = client.try_refund_single(&alice);
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        ContractError::CampaignStillActive
-    );
+    // Campaign is still Active — refund_single must panic.
+    client.refund_single(&alice);
 }
 
-/// Calling exactly at the deadline (not past it) is still rejected.
+/// Calling exactly at the deadline (not past it) — campaign still Active, panics.
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_single_at_deadline_boundary_returns_campaign_still_active() {
     let (env, client, creator, token, _admin) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -236,17 +240,15 @@ fn test_refund_single_at_deadline_boundary_returns_campaign_still_active() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline); // exactly at deadline, not past
-    let result = client.try_refund_single(&alice);
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        ContractError::CampaignStillActive
-    );
+    // finalize() would return CampaignStillActive here; campaign stays Active
+    client.refund_single(&alice); // panics — still Active
 }
 
 // ── Goal-reached guard ────────────────────────────────────────────────────────
 
-/// When the goal is met, `refund_single` returns `GoalReached`.
+/// When the goal is met, finalize() transitions to Succeeded; refund_single panics.
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_single_goal_reached_returns_goal_reached() {
     let (env, client, creator, token, _admin) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -258,12 +260,13 @@ fn test_refund_single_goal_reached_returns_goal_reached() {
     client.contribute(&alice, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
-    let result = client.try_refund_single(&alice);
-    assert_eq!(result.unwrap_err().unwrap(), ContractError::GoalReached);
+    client.finalize(); // Active → Succeeded
+    client.refund_single(&alice); // panics — not Expired
 }
 
 /// Goal exactly met (not exceeded) still blocks refunds.
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_single_goal_exactly_met_returns_goal_reached() {
     let (env, client, creator, token, _admin) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -275,15 +278,15 @@ fn test_refund_single_goal_exactly_met_returns_goal_reached() {
     client.contribute(&alice, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
-    let result = client.try_refund_single(&alice);
-    assert_eq!(result.unwrap_err().unwrap(), ContractError::GoalReached);
+    client.finalize(); // Active → Succeeded
+    client.refund_single(&alice); // panics — not Expired
 }
 
 // ── Campaign status guards ────────────────────────────────────────────────────
 
-/// `refund_single` panics when the campaign is Successful.
+/// `refund_single` panics when the campaign is Succeeded.
 #[test]
-#[should_panic(expected = "campaign is not active")]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_single_on_successful_campaign_panics() {
     let (env, client, creator, token, _admin) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -295,14 +298,15 @@ fn test_refund_single_on_successful_campaign_panics() {
     client.contribute(&alice, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
-    client.withdraw(); // sets status → Successful
+    client.finalize(); // Active → Succeeded
+    client.withdraw();
 
     client.refund_single(&alice); // must panic
 }
 
 /// `refund_single` panics when the campaign is Cancelled.
 #[test]
-#[should_panic(expected = "campaign is not active")]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_single_on_cancelled_campaign_panics() {
     let (env, client, creator, token, _admin) = setup();
     let deadline = env.ledger().timestamp() + 3_600;
@@ -355,6 +359,7 @@ fn test_refund_single_requires_contributor_auth() {
     );
     client.contribute(&alice, &500_000);
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     // Now attempt refund_single with alice's auth properly mocked.
     client.mock_auths(&[soroban_sdk::testutils::MockAuth {
@@ -387,13 +392,14 @@ fn test_refund_single_after_batch_refund_returns_nothing_to_refund() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund(); // deprecated batch path — zeroes alice's record
 
     // alice already got her tokens back via batch refund
     let tc = token::Client::new(&env, &token);
     assert_eq!(tc.balance(&alice), 500_000);
 
-    // refund_single should now return NothingToRefund (status is Refunded, amount is 0)
+    // refund_single should now return NothingToRefund (amount is 0)
     let result = client.try_refund_single(&alice);
     assert_eq!(result.unwrap_err().unwrap(), ContractError::NothingToRefund);
 }
@@ -428,6 +434,7 @@ fn test_refund_single_ignores_platform_fee() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund_single(&alice);
 
     // Alice gets 100% back — platform fee only applies on successful withdrawal.
@@ -452,6 +459,7 @@ fn test_refund_single_zeroes_contribution_record() {
     assert_eq!(client.contribution(&alice), 750_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund_single(&alice);
 
     assert_eq!(client.contribution(&alice), 0);
@@ -474,6 +482,7 @@ fn test_refund_single_partial_claims_leave_others_intact() {
     client.contribute(&bob, &200_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
 
     // Only alice claims.
     client.refund_single(&alice);
@@ -502,6 +511,7 @@ fn test_refund_single_minimum_contribution_amount() {
     client.contribute(&alice, &1_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // Active → Expired
     client.refund_single(&alice);
 
     let tc = token::Client::new(&env, &token);

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -311,6 +311,7 @@ fn test_withdraw_skips_nft_minting_when_nft_contract_not_set() {
     client.contribute(&contributor, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize();
 
     let token_client = token::Client::new(&env, &token_address);
     let before = token_client.balance(&creator);
@@ -319,7 +320,7 @@ fn test_withdraw_skips_nft_minting_when_nft_contract_not_set() {
     assert_eq!(client.total_raised(), 0);
 }
 
-/// Withdraw before deadline must return CampaignStillActive.
+/// Withdraw before finalize (deadline not passed) must return CampaignStillActive.
 #[test]
 fn test_withdraw_before_deadline_returns_error() {
     let (env, client, creator, token_address, admin) = setup_env();
@@ -331,15 +332,17 @@ fn test_withdraw_before_deadline_returns_error() {
     mint_to(&env, &token_address, &admin, &contributor, goal);
     client.contribute(&contributor, &goal);
 
-    let result = client.try_withdraw();
+    // finalize() before deadline returns CampaignStillActive
+    let result = client.try_finalize();
     assert_eq!(
         result.unwrap_err().unwrap(),
         crate::ContractError::CampaignStillActive
     );
 }
 
-/// Withdraw when goal not met must return GoalNotReached.
+/// Withdraw when goal not met: finalize transitions to Expired, withdraw panics.
 #[test]
+#[should_panic(expected = "campaign must be in Succeeded state to withdraw")]
 fn test_withdraw_goal_not_reached_returns_error() {
     let (env, client, creator, token_address, admin) = setup_env();
     let deadline = env.ledger().timestamp() + 3600;
@@ -350,11 +353,8 @@ fn test_withdraw_goal_not_reached_returns_error() {
     client.contribute(&contributor, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
-    let result = client.try_withdraw();
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        crate::ContractError::GoalNotReached
-    );
+    client.finalize(); // transitions to Expired
+    client.withdraw(); // panics — not Succeeded
 }
 
 /// Withdraw with platform fee deducts fee and sends remainder to creator.
@@ -386,6 +386,7 @@ fn test_withdraw_with_platform_fee() {
     client.contribute(&contributor, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize();
     client.withdraw();
 
     let token_client = token::Client::new(&env, &token_address);
@@ -416,6 +417,7 @@ fn test_withdraw_mints_nft_for_each_contributor() {
     client.contribute(&bob, &400_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize();
     client.withdraw();
 
     // Both contributors should have received an NFT.
@@ -438,6 +440,7 @@ fn test_withdraw_skips_nft_mint_when_contract_not_set() {
 
     env.ledger().set_timestamp(deadline + 1);
     // Should not panic — no NFT contract set.
+    client.finalize();
     client.withdraw();
     assert_eq!(client.nft_contract(), None);
 }
@@ -456,6 +459,7 @@ fn test_refund_returns_tokens() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize(); // transitions to Expired
     client.refund();
 
     let token_client = token::Client::new(&env, &token_address);
@@ -463,9 +467,9 @@ fn test_refund_returns_tokens() {
     assert_eq!(client.total_raised(), 0);
 }
 
-/// Second refund call must panic — status is already Refunded.
+/// Second refund call must panic — status is already Expired (not Active).
 #[test]
-#[should_panic(expected = "campaign is not active")]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_double_refund_panics() {
     let (env, client, creator, token_address, admin) = setup_env();
     let deadline = env.ledger().timestamp() + 3600;
@@ -476,12 +480,14 @@ fn test_double_refund_panics() {
     client.contribute(&alice, &500_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize();
     client.refund();
-    client.refund(); // panics
+    client.refund(); // panics — already Expired, not Active
 }
 
-/// Refund when goal is reached must return GoalReached.
+/// Refund when goal is reached: finalize transitions to Succeeded, refund panics.
 #[test]
+#[should_panic(expected = "campaign must be in Expired state to refund")]
 fn test_refund_when_goal_reached_returns_error() {
     let (env, client, creator, token_address, admin) = setup_env();
     let deadline = env.ledger().timestamp() + 3600;
@@ -493,11 +499,9 @@ fn test_refund_when_goal_reached_returns_error() {
     client.contribute(&contributor, &goal);
 
     env.ledger().set_timestamp(deadline + 1);
-    let result = client.try_refund();
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        crate::ContractError::GoalReached
-    );
+    client.finalize(); // transitions to Succeeded
+    client.refund(); // panics — not Expired
+}
 }
 
 // ── cancel ───────────────────────────────────────────────────────────────────

--- a/contracts/crowdfund/src/withdraw_event_emission_test.rs
+++ b/contracts/crowdfund/src/withdraw_event_emission_test.rs
@@ -120,6 +120,7 @@ fn count_events_with_topic(env: &Env, t1: &str, t2: &str) -> usize {
 fn test_withdraw_mints_all_when_within_cap() {
     let count = MAX_NFT_MINT_BATCH - 1;
     let (env, client, _creator, _token, nft_id) = setup(count);
+    client.finalize();
     client.withdraw();
 
     let nft = BoundedMockNftClient::new(&env, &nft_id);
@@ -131,6 +132,7 @@ fn test_withdraw_mints_all_when_within_cap() {
 fn test_withdraw_caps_minting_at_max_batch() {
     let count = MAX_NFT_MINT_BATCH + 10;
     let (env, client, _creator, _token, nft_id) = setup(count);
+    client.finalize();
     client.withdraw();
 
     let nft = BoundedMockNftClient::new(&env, &nft_id);
@@ -141,6 +143,7 @@ fn test_withdraw_caps_minting_at_max_batch() {
 #[test]
 fn test_withdraw_mints_exactly_at_cap_boundary() {
     let (env, client, _creator, _token, nft_id) = setup(MAX_NFT_MINT_BATCH);
+    client.finalize();
     client.withdraw();
 
     let nft = BoundedMockNftClient::new(&env, &nft_id);
@@ -151,6 +154,7 @@ fn test_withdraw_mints_exactly_at_cap_boundary() {
 #[test]
 fn test_withdraw_emits_single_batch_event() {
     let (env, client, _creator, _token, _nft_id) = setup(5);
+    client.finalize();
     client.withdraw();
 
     assert_eq!(
@@ -193,6 +197,7 @@ fn test_withdraw_no_batch_event_without_nft_contract() {
     client.contribute(&contributor, &1_000);
 
     env.ledger().set_timestamp(deadline + 1);
+    client.finalize();
     client.withdraw();
 
     assert_eq!(
@@ -205,6 +210,7 @@ fn test_withdraw_no_batch_event_without_nft_contract() {
 #[test]
 fn test_withdraw_emits_withdrawn_event_once() {
     let (env, client, _creator, _token, _nft_id) = setup(2);
+    client.finalize();
     client.withdraw();
 
     assert_eq!(count_events_with_topic(&env, "campaign", "withdrawn"), 1);
@@ -219,6 +225,7 @@ fn test_withdraw_no_batch_event_when_no_eligible_contributors() {
     // but minted count should be 1 (>0 contribution), so batch event fires.
     // This test verifies the event count is still exactly 1 (not 0 or >1).
     let (env, client, _creator, _token, _nft_id) = setup(1);
+    client.finalize();
     client.withdraw();
 
     assert_eq!(

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2057,7 +2056,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2081,7 +2079,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2786,16 +2783,6 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
-    "node_modules/@trysound/sax": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
@@ -2944,7 +2931,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3609,7 +3595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4873,7 +4858,6 @@
       "integrity": "sha512-AkXIIFcaazymvey2i/+F94XRnM6TsVLZDhBMLsd1Sf/W0wzsvvpjeyUrCZD6HGG4SDYPgDJDBKeiJTBb10WzMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.3.0",
         "@jest/types": "30.3.0",
@@ -5510,7 +5494,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -6913,7 +6896,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6989,7 +6971,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
### Summary

Implements an explicit state machine for the campaign lifecycle, eliminating "state 
bleeding" where functions like withdraw could be called while a campaign was still 
logically active.

### Changes

New Status enum variants

| Before | After |
|--------|-------|
| Active | Active |
| Successful | Succeeded |
| Refunded | Expired (new) |
| Cancelled | Cancelled |

New finalize() function

Transitions the campaign from Active to either Succeeded or Expired based on the deadline 
and total raised. Permissionless — anyone can call it after the deadline.

Active ──(deadline passed, goal met)──► Succeeded
Active ──(deadline passed, goal not met)──► Expired
Active ──(creator cancels)──► Cancelled


New status() view function — returns the current stored campaign state.

withdraw() security hardening
- Now requires Status::Succeeded (set by finalize() when goal is met)
- Removed inline deadline/goal checks — the state machine is the single source of truth
- A creator cannot withdraw while the campaign is Active, even if the goal has been met

refund() / refund_single() security hardening
- Both now require Status::Expired (set by finalize() when goal is not met)
- validate_refund_preconditions() simplified: checks Status::Expired only
- Refunds are impossible on a Succeeded campaign — no accidental fund drain

### Security

The two-step finalize → withdraw/refund design is the core security improvement. 
Previously, withdraw and refund each independently re-evaluated deadline and goal 
conditions, creating a window where concurrent or mis-ordered calls could produce 
unexpected behavior. Now the state transition is atomic and irreversible.

### Test Updates

All existing tests updated to call finalize() before withdraw() or refund(). Panic message 
expectations updated to match new state guards (
"campaign must be in Succeeded state to withdraw", 
"campaign must be in Expired state to refund").

closes #483 