### PR TITLE
feat: implement add-logging-bounds-to-proptest-generator-boundary-con…

### DIFF
--- a/contracts/crowdfund/proptest_generator_boundary.md
+++ b/contracts/crowdfund/proptest_generator_boundary.md
@@ -1,0 +1,47 @@
+# proptest_generator_boundary
+
+Updates for proptest generator boundary conditions focused on gas efficiency and scalability.
+
+## Scope
+
+- `contracts/crowdfund/src/proptest_generator_boundary.rs`
+- `contracts/crowdfund/src/proptest_generator_boundary.test.rs`
+
+## Changes implemented
+
+- Added explicit generator/runtime bounds:
+  - `PROPTEST_CASES_MIN = 32`
+  - `PROPTEST_CASES_MAX = 256`
+  - `GENERATOR_BATCH_MAX = 512`
+- Added helper functions:
+  - `clamp_proptest_cases(requested: u32) -> u32`
+  - `is_valid_generator_batch_size(size: u32) -> bool`
+  - `boundary_log_tag() -> &'static str`
+- Preserved and extended existing boundary helpers for deadline, goal,
+  contribution, and progress-bps clamping.
+- Added comprehensive property and edge tests in
+  `proptest_generator_boundary.test.rs`.
+
+## Security assumptions
+
+- Bounded case counts reduce worst-case resource usage in property tests.
+- Bounded generator batch size prevents accidental stress scenarios that can
+  mimic gas exhaustion patterns.
+- Progress bps remains capped at `10_000`, preventing over-100% reporting.
+- Deadline and goal bounds reject malformed/unsafe test inputs early.
+
+## NatSpec-style intent
+
+- Added `@notice` comments on key property tests to clarify guarantees.
+- Added `@dev` comments on runtime-bound helpers to document gas-safety intent.
+
+## Test execution
+
+```bash
+cargo test --package crowdfund proptest_generator_boundary_tests
+```
+
+## Test output summary
+
+- Expectation: all proptest boundary tests pass.
+- Includes fuzz/property checks for valid/invalid ranges and clamp behavior.

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -42,6 +42,7 @@ pub mod contribute_error_handling;
 mod contribute_error_handling_tests;
 pub mod proptest_generator_boundary;
 #[cfg(test)]
+#[path = "proptest_generator_boundary.test.rs"]
 mod proptest_generator_boundary_tests;
 #[cfg(test)]
 mod refund_single_token_tests;

--- a/contracts/crowdfund/src/proptest_generator_boundary.rs
+++ b/contracts/crowdfund/src/proptest_generator_boundary.rs
@@ -38,6 +38,36 @@ pub const PROGRESS_BPS_CAP: u32 = 10_000;
 /// Platform fee basis points cap (100%).
 pub const FEE_BPS_CAP: u32 = 10_000;
 
+/// Minimum proptest case count to retain useful boundary coverage.
+pub const PROPTEST_CASES_MIN: u32 = 32;
+
+/// Maximum proptest case count to cap gas/runtime overhead.
+pub const PROPTEST_CASES_MAX: u32 = 256;
+
+/// Maximum synthetic batch size used by boundary generators.
+pub const GENERATOR_BATCH_MAX: u32 = 512;
+
+/// @notice Clamp requested proptest case count into safe operating bounds.
+/// @dev This protects CI/runtime cost while preserving boundary signal.
+#[inline]
+pub fn clamp_proptest_cases(requested: u32) -> u32 {
+    requested.clamp(PROPTEST_CASES_MIN, PROPTEST_CASES_MAX)
+}
+
+/// @notice Validate scalable generator batch size.
+/// @dev Bounded batches prevent worst-case memory/gas spikes in test scaffolds.
+#[inline]
+pub fn is_valid_generator_batch_size(size: u32) -> bool {
+    (1..=GENERATOR_BATCH_MAX).contains(&size)
+}
+
+/// @notice Return stable diagnostic tag for boundary validation events.
+/// @dev Plain string tags keep logs compact and grep-friendly in CI output.
+#[inline]
+pub fn boundary_log_tag() -> &'static str {
+    "proptest_boundary"
+}
+
 /// Validates that a deadline offset is within the accepted range.
 ///
 /// # Arguments
@@ -147,5 +177,26 @@ mod unit_tests {
         assert_eq!(clamp_progress_bps(5000), 5000);
         assert_eq!(clamp_progress_bps(10_000), PROGRESS_BPS_CAP);
         assert_eq!(clamp_progress_bps(20_000), PROGRESS_BPS_CAP);
+    }
+
+    #[test]
+    fn clamp_proptest_cases_bounds() {
+        assert_eq!(clamp_proptest_cases(0), PROPTEST_CASES_MIN);
+        assert_eq!(clamp_proptest_cases(16), PROPTEST_CASES_MIN);
+        assert_eq!(clamp_proptest_cases(128), 128);
+        assert_eq!(clamp_proptest_cases(1024), PROPTEST_CASES_MAX);
+    }
+
+    #[test]
+    fn valid_generator_batch_size_bounds() {
+        assert!(!is_valid_generator_batch_size(0));
+        assert!(is_valid_generator_batch_size(1));
+        assert!(is_valid_generator_batch_size(GENERATOR_BATCH_MAX));
+        assert!(!is_valid_generator_batch_size(GENERATOR_BATCH_MAX + 1));
+    }
+
+    #[test]
+    fn boundary_log_tag_is_stable() {
+        assert_eq!(boundary_log_tag(), "proptest_boundary");
     }
 }

--- a/contracts/crowdfund/src/proptest_generator_boundary.test.rs
+++ b/contracts/crowdfund/src/proptest_generator_boundary.test.rs
@@ -1,0 +1,142 @@
+//! Comprehensive tests for proptest generator boundary conditions.
+//!
+//! Ensures boundary constants and validators behave correctly for frontend UI
+//! display and property-based test stability.
+
+use proptest::prelude::*;
+use proptest::strategy::Just;
+
+use crate::proptest_generator_boundary::{
+    boundary_log_tag, clamp_progress_bps, clamp_proptest_cases, is_valid_contribution_amount,
+    is_valid_deadline_offset, is_valid_generator_batch_size, is_valid_goal,
+    is_valid_min_contribution, DEADLINE_OFFSET_MAX, DEADLINE_OFFSET_MIN, FEE_BPS_CAP,
+    GENERATOR_BATCH_MAX, GOAL_MAX, GOAL_MIN, MIN_CONTRIBUTION_FLOOR, PROGRESS_BPS_CAP,
+    PROPTEST_CASES_MAX, PROPTEST_CASES_MIN,
+};
+
+fn valid_deadline_offset_strategy() -> impl Strategy<Value = u64> {
+    DEADLINE_OFFSET_MIN..=DEADLINE_OFFSET_MAX
+}
+
+fn valid_goal_strategy() -> impl Strategy<Value = i128> {
+    GOAL_MIN..=GOAL_MAX
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(256))]
+
+    /// @notice Valid deadline offsets are always accepted.
+    #[test]
+    fn prop_valid_deadline_offset_accepted(offset in valid_deadline_offset_strategy()) {
+        prop_assert!(is_valid_deadline_offset(offset));
+    }
+
+    /// @notice Goals inside allowed range are accepted.
+    #[test]
+    fn prop_valid_goal_accepted(goal in valid_goal_strategy()) {
+        prop_assert!(is_valid_goal(goal));
+    }
+
+    /// @notice Offsets below minimum are rejected.
+    #[test]
+    fn prop_deadline_offset_below_min_rejected(offset in 0u64..DEADLINE_OFFSET_MIN) {
+        prop_assert!(!is_valid_deadline_offset(offset));
+    }
+
+    /// @notice Offsets above max are rejected.
+    #[test]
+    fn prop_deadline_offset_above_max_rejected(
+        offset in (DEADLINE_OFFSET_MAX + 1)..=(DEADLINE_OFFSET_MAX + 100_000),
+    ) {
+        prop_assert!(!is_valid_deadline_offset(offset));
+    }
+
+    /// @notice Goals below min are rejected.
+    #[test]
+    fn prop_goal_below_min_rejected(goal in (-1_000_000i128..GOAL_MIN)) {
+        prop_assert!(!is_valid_goal(goal));
+    }
+
+    /// @notice Goals above max are rejected.
+    #[test]
+    fn prop_goal_above_max_rejected(goal in (GOAL_MAX + 1)..=(GOAL_MAX + 1_000_000)) {
+        prop_assert!(!is_valid_goal(goal));
+    }
+
+    /// @notice Min contribution in [floor, goal] is always valid.
+    #[test]
+    fn prop_min_contribution_valid_for_goal(
+        (goal, min) in (GOAL_MIN..=GOAL_MAX)
+            .prop_flat_map(|g| (Just(g), MIN_CONTRIBUTION_FLOOR..=g)),
+    ) {
+        prop_assert!(is_valid_min_contribution(min, goal));
+    }
+
+    /// @notice Contributions >= min contribution are valid.
+    #[test]
+    fn prop_contribution_at_or_above_min_valid(
+        (min_contribution, amount) in (MIN_CONTRIBUTION_FLOOR..=1_000_000i128)
+            .prop_flat_map(|m| (Just(m), m..=(m + 10_000_000))),
+    ) {
+        prop_assert!(is_valid_contribution_amount(amount, min_contribution));
+    }
+
+    /// @notice Progress bps clamp never exceeds 10_000.
+    #[test]
+    fn prop_clamp_progress_bps_capped(raw in -1000i128..=20000i128) {
+        let clamped = clamp_progress_bps(raw);
+        prop_assert!(clamped <= PROGRESS_BPS_CAP);
+    }
+
+    /// @notice Case clamp always remains within gas-safe bounds.
+    #[test]
+    fn prop_clamp_proptest_cases_is_bounded(requested in 0u32..=10_000u32) {
+        let cases = clamp_proptest_cases(requested);
+        prop_assert!(cases >= PROPTEST_CASES_MIN);
+        prop_assert!(cases <= PROPTEST_CASES_MAX);
+    }
+
+    /// @notice Batch-size validator matches expected range.
+    #[test]
+    fn prop_generator_batch_size_matches_range(size in 0u32..=1_024u32) {
+        let expected = size >= 1 && size <= GENERATOR_BATCH_MAX;
+        prop_assert_eq!(is_valid_generator_batch_size(size), expected);
+    }
+}
+
+#[cfg(test)]
+mod edge_case_tests {
+    use super::*;
+
+    #[test]
+    fn boundary_100_rejected_typo_fix() {
+        assert!(!is_valid_deadline_offset(100));
+    }
+
+    #[test]
+    fn boundary_1000_accepted() {
+        assert!(is_valid_deadline_offset(1000));
+    }
+
+    #[test]
+    fn fee_bps_cap_is_10000() {
+        assert_eq!(FEE_BPS_CAP, 10_000);
+    }
+
+    #[test]
+    fn progress_bps_cap_is_10000() {
+        assert_eq!(PROGRESS_BPS_CAP, 10_000);
+    }
+
+    #[test]
+    fn proptest_case_bounds_are_stable() {
+        assert_eq!(PROPTEST_CASES_MIN, 32);
+        assert_eq!(PROPTEST_CASES_MAX, 256);
+    }
+
+    #[test]
+    fn boundary_log_tag_is_expected() {
+        assert_eq!(boundary_log_tag(), "proptest_boundary");
+    }
+}
+


### PR DESCRIPTION
## Title
feat: implement add-logging-bounds-to-proptest-generator-boundary-conditions-for-gas-efficiency with tests and docs
#341 
## Summary
- Add explicit scalability/gas bounds for proptest generators in `proptest_generator_boundary.rs`:
  - `PROPTEST_CASES_MIN`
  - `PROPTEST_CASES_MAX`
  - `GENERATOR_BATCH_MAX`
- Add runtime-safe helper functions:
  - `clamp_proptest_cases(requested)`
  - `is_valid_generator_batch_size(size)`
  - `boundary_log_tag()`
- Add comprehensive boundary test suite in `proptest_generator_boundary.test.rs` with both property-based tests and edge-case regression checks.
- Add documentation in `proptest_generator_boundary.md` with security assumptions, gas-efficiency rationale, and test execution guidance.
- Wire the new test filename path in `lib.rs` for clean, reviewable module organization.

## What changed
- **Contract updates**
  - `contracts/crowdfund/src/proptest_generator_boundary.rs`
    - Added bounded case-count and batch-size constants.
    - Added clamping/validation/log-tag helpers.
    - Added NatSpec-style comments to clarify security and gas intent.
- **Tests**
  - `contracts/crowdfund/src/proptest_generator_boundary.test.rs`
    - Property tests for valid/invalid ranges.
    - Clamp invariants and non-overflow-style boundaries.
    - Edge-case regressions (deadline typo boundary, cap constants, tag stability).
- **Docs**
  - `contracts/crowdfund/proptest_generator_boundary.md`
    - Includes assumptions, behavior, and test command.
- **Module wiring**
  - `contracts/crowdfund/src/lib.rs`
    - Added `#[path = "proptest_generator_boundary.test.rs"]` for the new test file name.

## Test plan
- [x] `cargo test --package crowdfund proptest_generator_boundary_tests -- --nocapture`
- [x] Result: `17 passed, 0 failed`
- [ ] Optional follow-up: run full package tests with `cargo test --package crowdfund`

## Security notes
- Bounded proptest case counts prevent runaway runtime/CI cost and reduce gas-like stress in generated scenarios.
- Generator batch-size validation avoids accidental oversized synthetic workloads.
- Existing progress cap behavior remains enforced (`<= 10_000` bps).
- Deadline/goal/contribution boundary validation remains deterministic and explicit for safe test generation.