### PR TITLE
feat: implement fix-typo-in-wasm-build-pipeline-caching-for-frontend-…

### DIFF
--- a/src/components/wasm_build_pipeline.md
+++ b/src/components/wasm_build_pipeline.md
@@ -1,0 +1,121 @@
+# WASM Build Pipeline Caching
+
+Utility for managing WASM build artifact caching in the Stellar Raise frontend UI.
+
+## Overview
+
+`wasm_build_pipeline.tsx` provides a type-safe, secure in-memory cache for WASM build outputs. It improves developer experience by avoiding redundant rebuilds during development and gives the frontend a reliable way to check whether a cached artifact is still valid before re-fetching or re-compiling.
+
+## Features
+
+- Key and value validation with allowlist-based security
+- Configurable TTL per entry (default: 24 hours)
+- Hash-based cache invalidation (`isValid`)
+- Automatic eviction of stale entries on read
+- Manual bulk eviction via `evictExpired()`
+- Cache statistics for monitoring and debugging
+- Zero external dependencies — works in browser and Node/test environments
+
+## Security
+
+All inputs are validated before storage:
+
+| Threat | Mitigation |
+|---|---|
+| Key injection | Keys must match `/^[a-zA-Z0-9_\-\.]+$/` |
+| Script injection in values | `<script>`, `javascript:`, `data:text/html`, and inline event handlers are rejected |
+| Oversized payloads | Values are capped at 5 MB (`MAX_CACHE_VALUE_BYTES`) |
+| Hash tampering | Hashes must be non-empty hexadecimal strings |
+
+## Usage
+
+### Basic set / get
+
+```ts
+import { wasmBuildCache } from './wasm_build_pipeline';
+
+// Store a build artifact
+wasmBuildCache.set('crowdfund-v1', wasmBase64, buildHash);
+
+// Retrieve it
+const entry = wasmBuildCache.get('crowdfund-v1');
+if (entry) {
+  console.log(entry.value, entry.hash);
+}
+```
+
+### Custom TTL and label
+
+```ts
+wasmBuildCache.set('crowdfund-v1', wasmBase64, buildHash, {
+  ttlMs: 60 * 60 * 1000, // 1 hour
+  label: 'crowdfund contract release build',
+});
+```
+
+### Hash-based invalidation
+
+```ts
+const isStillValid = wasmBuildCache.isValid('crowdfund-v1', latestBuildHash);
+if (!isStillValid) {
+  // Re-fetch or re-compile
+}
+```
+
+### Evict stale entries
+
+```ts
+const removed = wasmBuildCache.evictExpired();
+console.log(`Evicted ${removed} stale entries`);
+```
+
+### Cache statistics
+
+```ts
+const stats = wasmBuildCache.getStats();
+console.log(stats.totalEntries, stats.expiredEntries, stats.validEntries);
+```
+
+## API Reference
+
+### `WasmBuildCache`
+
+| Method | Description |
+|---|---|
+| `set(key, value, hash, opts?)` | Store an artifact |
+| `get(key)` | Retrieve an artifact (returns `null` if missing or expired) |
+| `has(key)` | Check existence without returning the value |
+| `delete(key)` | Remove a single entry |
+| `clear()` | Remove all entries |
+| `evictExpired()` | Remove all expired entries; returns count removed |
+| `getStats()` | Return `WasmCacheStats` object |
+| `isValid(key, hash)` | Returns `true` if entry exists, is not expired, and hash matches |
+
+### `WasmCacheValidator` (static)
+
+| Method | Description |
+|---|---|
+| `validateKey(key)` | Throws `WasmCacheError` if key is invalid |
+| `validateValue(value)` | Throws `WasmCacheError` if value is unsafe or too large |
+| `validateHash(hash)` | Throws `WasmCacheError` if hash is not a hex string |
+
+### Exported constants
+
+| Constant | Value | Description |
+|---|---|---|
+| `CACHE_KEY_PREFIX` | `'wasm_build_cache_'` | Namespace prefix for all keys |
+| `DEFAULT_CACHE_TTL_MS` | `86400000` (24 h) | Default entry lifetime |
+| `MAX_CACHE_VALUE_BYTES` | `5242880` (5 MB) | Maximum value size |
+
+## Running Tests
+
+```bash
+npx jest src/components/wasm_build_pipeline.test.tsx --coverage
+```
+
+Expected coverage: ≥ 95 % statements, branches, functions, and lines.
+
+## Notes
+
+- The backing store is an in-memory `Map`. Entries do not persist across page reloads. Swap `_store` for a `localStorage` adapter if persistence is needed.
+- `WasmCacheError` is thrown for all validation failures — wrap calls in `try/catch` in production code.

--- a/src/components/wasm_build_pipeline.test.tsx
+++ b/src/components/wasm_build_pipeline.test.tsx
@@ -1,0 +1,433 @@
+/**
+ * @title WASM Build Pipeline Caching – Test Suite
+ * @notice Comprehensive tests covering happy paths, edge cases, and security
+ * @author Stellar Raise Contracts Team
+ *
+ * Run with:  npx jest src/components/wasm_build_pipeline.test.tsx --coverage
+ */
+
+import {
+  WasmBuildCache,
+  WasmCacheValidator,
+  WasmCacheError,
+  wasmBuildCache,
+  CACHE_KEY_PREFIX,
+  DEFAULT_CACHE_TTL_MS,
+  MAX_CACHE_VALUE_BYTES,
+} from './wasm_build_pipeline';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_KEY = 'crowdfund-v1';
+const VALID_HASH = 'deadbeef1234abcd';
+const VALID_VALUE = 'AGFzbQEAAAA='; // minimal base64-encoded WASM stub
+
+// ---------------------------------------------------------------------------
+// WasmCacheValidator
+// ---------------------------------------------------------------------------
+
+describe('WasmCacheValidator', () => {
+  // --- validateKey ---
+  describe('validateKey', () => {
+    it('accepts alphanumeric keys', () => {
+      expect(() => WasmCacheValidator.validateKey('crowdfund123')).not.toThrow();
+    });
+
+    it('accepts keys with hyphens, underscores, and dots', () => {
+      expect(() => WasmCacheValidator.validateKey('build_v1.0-rc')).not.toThrow();
+    });
+
+    it('throws for empty key', () => {
+      expect(() => WasmCacheValidator.validateKey('')).toThrow(WasmCacheError);
+    });
+
+    it('throws for whitespace-only key', () => {
+      expect(() => WasmCacheValidator.validateKey('   ')).toThrow(WasmCacheError);
+    });
+
+    it('throws for key with spaces', () => {
+      expect(() => WasmCacheValidator.validateKey('bad key')).toThrow(WasmCacheError);
+    });
+
+    it('throws for key with special characters', () => {
+      expect(() => WasmCacheValidator.validateKey('key<script>')).toThrow(WasmCacheError);
+    });
+
+    it('throws for key with slashes', () => {
+      expect(() => WasmCacheValidator.validateKey('path/to/key')).toThrow(WasmCacheError);
+    });
+  });
+
+  // --- validateValue ---
+  describe('validateValue', () => {
+    it('accepts a normal base64 WASM value', () => {
+      expect(() => WasmCacheValidator.validateValue(VALID_VALUE)).not.toThrow();
+    });
+
+    it('accepts a plain JSON string', () => {
+      expect(() =>
+        WasmCacheValidator.validateValue(JSON.stringify({ version: '1.0.0' }))
+      ).not.toThrow();
+    });
+
+    it('throws for <script> tag injection', () => {
+      expect(() =>
+        WasmCacheValidator.validateValue('<script>alert(1)</script>')
+      ).toThrow(WasmCacheError);
+    });
+
+    it('throws for javascript: protocol', () => {
+      expect(() =>
+        WasmCacheValidator.validateValue('javascript:alert(1)')
+      ).toThrow(WasmCacheError);
+    });
+
+    it('throws for data:text/html injection', () => {
+      expect(() =>
+        WasmCacheValidator.validateValue('data:text/html,<h1>pwned</h1>')
+      ).toThrow(WasmCacheError);
+    });
+
+    it('throws for inline event handler injection', () => {
+      expect(() =>
+        WasmCacheValidator.validateValue('<img onerror=alert(1)>')
+      ).toThrow(WasmCacheError);
+    });
+
+    it('throws when value exceeds MAX_CACHE_VALUE_BYTES', () => {
+      const oversized = 'x'.repeat(MAX_CACHE_VALUE_BYTES + 1);
+      expect(() => WasmCacheValidator.validateValue(oversized)).toThrow(WasmCacheError);
+    });
+
+    it('accepts value exactly at the size limit', () => {
+      const atLimit = 'x'.repeat(MAX_CACHE_VALUE_BYTES);
+      expect(() => WasmCacheValidator.validateValue(atLimit)).not.toThrow();
+    });
+  });
+
+  // --- validateHash ---
+  describe('validateHash', () => {
+    it('accepts a valid lowercase hex hash', () => {
+      expect(() => WasmCacheValidator.validateHash('deadbeef')).not.toThrow();
+    });
+
+    it('accepts a valid uppercase hex hash', () => {
+      expect(() => WasmCacheValidator.validateHash('DEADBEEF')).not.toThrow();
+    });
+
+    it('accepts a full SHA-256 hex string', () => {
+      expect(() =>
+        WasmCacheValidator.validateHash(
+          'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
+        )
+      ).not.toThrow();
+    });
+
+    it('throws for empty hash', () => {
+      expect(() => WasmCacheValidator.validateHash('')).toThrow(WasmCacheError);
+    });
+
+    it('throws for hash with non-hex characters', () => {
+      expect(() => WasmCacheValidator.validateHash('xyz123')).toThrow(WasmCacheError);
+    });
+
+    it('throws for hash with spaces', () => {
+      expect(() => WasmCacheValidator.validateHash('dead beef')).toThrow(WasmCacheError);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WasmBuildCache – core operations
+// ---------------------------------------------------------------------------
+
+describe('WasmBuildCache', () => {
+  let cache: WasmBuildCache;
+
+  beforeEach(() => {
+    cache = new WasmBuildCache();
+  });
+
+  // --- set / get ---
+  describe('set and get', () => {
+    it('stores and retrieves a valid entry', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      const entry = cache.get(VALID_KEY);
+      expect(entry).not.toBeNull();
+      expect(entry!.value).toBe(VALID_VALUE);
+      expect(entry!.hash).toBe(VALID_HASH);
+    });
+
+    it('stores entry with custom TTL', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { ttlMs: 5000 });
+      const entry = cache.get(VALID_KEY);
+      expect(entry).not.toBeNull();
+      expect(entry!.expiresAt - entry!.createdAt).toBe(5000);
+    });
+
+    it('stores entry with a label', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { label: 'crowdfund contract' });
+      const entry = cache.get(VALID_KEY);
+      expect(entry!.label).toBe('crowdfund contract');
+    });
+
+    it('uses DEFAULT_CACHE_TTL_MS when no TTL is provided', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      const entry = cache.get(VALID_KEY);
+      expect(entry!.expiresAt - entry!.createdAt).toBe(DEFAULT_CACHE_TTL_MS);
+    });
+
+    it('returns null for a missing key', () => {
+      expect(cache.get('nonexistent')).toBeNull();
+    });
+
+    it('returns null for an expired entry', () => {
+      jest.useFakeTimers();
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { ttlMs: 1000 });
+      jest.advanceTimersByTime(2000);
+      expect(cache.get(VALID_KEY)).toBeNull();
+      jest.useRealTimers();
+    });
+
+    it('evicts the expired entry on get', () => {
+      jest.useFakeTimers();
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { ttlMs: 1000 });
+      jest.advanceTimersByTime(2000);
+      cache.get(VALID_KEY); // triggers eviction
+      expect(cache.getStats().totalEntries).toBe(0);
+      jest.useRealTimers();
+    });
+
+    it('throws on set with invalid key', () => {
+      expect(() => cache.set('bad key!', VALID_VALUE, VALID_HASH)).toThrow(WasmCacheError);
+    });
+
+    it('throws on set with dangerous value', () => {
+      expect(() =>
+        cache.set(VALID_KEY, '<script>alert(1)</script>', VALID_HASH)
+      ).toThrow(WasmCacheError);
+    });
+
+    it('throws on set with invalid hash', () => {
+      expect(() => cache.set(VALID_KEY, VALID_VALUE, 'not-hex!')).toThrow(WasmCacheError);
+    });
+
+    it('throws on get with invalid key', () => {
+      expect(() => cache.get('')).toThrow(WasmCacheError);
+    });
+  });
+
+  // --- has ---
+  describe('has', () => {
+    it('returns true for a valid, non-expired entry', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      expect(cache.has(VALID_KEY)).toBe(true);
+    });
+
+    it('returns false for a missing key', () => {
+      expect(cache.has('missing')).toBe(false);
+    });
+
+    it('returns false for an expired entry', () => {
+      jest.useFakeTimers();
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { ttlMs: 500 });
+      jest.advanceTimersByTime(1000);
+      expect(cache.has(VALID_KEY)).toBe(false);
+      jest.useRealTimers();
+    });
+  });
+
+  // --- delete ---
+  describe('delete', () => {
+    it('removes an existing entry', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      cache.delete(VALID_KEY);
+      expect(cache.has(VALID_KEY)).toBe(false);
+    });
+
+    it('does not throw when deleting a non-existent key', () => {
+      expect(() => cache.delete('nonexistent')).not.toThrow();
+    });
+
+    it('throws for invalid key', () => {
+      expect(() => cache.delete('')).toThrow(WasmCacheError);
+    });
+  });
+
+  // --- clear ---
+  describe('clear', () => {
+    it('removes all entries', () => {
+      cache.set('key1', VALID_VALUE, VALID_HASH);
+      cache.set('key2', VALID_VALUE, VALID_HASH);
+      cache.clear();
+      expect(cache.getStats().totalEntries).toBe(0);
+    });
+
+    it('does not throw on an already-empty cache', () => {
+      expect(() => cache.clear()).not.toThrow();
+    });
+  });
+
+  // --- evictExpired ---
+  describe('evictExpired', () => {
+    it('removes only expired entries and returns the count', () => {
+      jest.useFakeTimers();
+      cache.set('fresh', VALID_VALUE, VALID_HASH, { ttlMs: 10_000 });
+      cache.set('stale1', VALID_VALUE, VALID_HASH, { ttlMs: 100 });
+      cache.set('stale2', VALID_VALUE, VALID_HASH, { ttlMs: 100 });
+      jest.advanceTimersByTime(500);
+      const removed = cache.evictExpired();
+      expect(removed).toBe(2);
+      expect(cache.has('fresh')).toBe(true);
+      jest.useRealTimers();
+    });
+
+    it('returns 0 when no entries are expired', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      expect(cache.evictExpired()).toBe(0);
+    });
+
+    it('returns 0 on an empty cache', () => {
+      expect(cache.evictExpired()).toBe(0);
+    });
+  });
+
+  // --- getStats ---
+  describe('getStats', () => {
+    it('returns correct stats for a populated cache', () => {
+      jest.useFakeTimers();
+      cache.set('a', VALID_VALUE, VALID_HASH, { ttlMs: 10_000 });
+      cache.set('b', VALID_VALUE, VALID_HASH, { ttlMs: 100 });
+      jest.advanceTimersByTime(500);
+      const stats = cache.getStats();
+      expect(stats.totalEntries).toBe(2);
+      expect(stats.expiredEntries).toBe(1);
+      expect(stats.validEntries).toBe(1);
+      expect(stats.keys).toContain('a');
+      expect(stats.keys).toContain('b');
+      jest.useRealTimers();
+    });
+
+    it('returns zero counts for an empty cache', () => {
+      const stats = cache.getStats();
+      expect(stats.totalEntries).toBe(0);
+      expect(stats.expiredEntries).toBe(0);
+      expect(stats.validEntries).toBe(0);
+      expect(stats.keys).toHaveLength(0);
+    });
+  });
+
+  // --- isValid ---
+  describe('isValid', () => {
+    it('returns true when entry exists and hash matches', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      expect(cache.isValid(VALID_KEY, VALID_HASH)).toBe(true);
+    });
+
+    it('returns false when hash does not match', () => {
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH);
+      expect(cache.isValid(VALID_KEY, 'aabbccdd')).toBe(false);
+    });
+
+    it('returns false for a missing key', () => {
+      expect(cache.isValid('missing', VALID_HASH)).toBe(false);
+    });
+
+    it('returns false for an expired entry', () => {
+      jest.useFakeTimers();
+      cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { ttlMs: 100 });
+      jest.advanceTimersByTime(500);
+      expect(cache.isValid(VALID_KEY, VALID_HASH)).toBe(false);
+      jest.useRealTimers();
+    });
+
+    it('throws for invalid key', () => {
+      expect(() => cache.isValid('', VALID_HASH)).toThrow(WasmCacheError);
+    });
+
+    it('throws for invalid hash', () => {
+      expect(() => cache.isValid(VALID_KEY, 'not-hex')).toThrow(WasmCacheError);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CACHE_KEY_PREFIX namespacing
+// ---------------------------------------------------------------------------
+
+describe('CACHE_KEY_PREFIX', () => {
+  it('is a non-empty string', () => {
+    expect(typeof CACHE_KEY_PREFIX).toBe('string');
+    expect(CACHE_KEY_PREFIX.length).toBeGreaterThan(0);
+  });
+
+  it('is used to namespace keys (stats keys strip the prefix)', () => {
+    const cache = new WasmBuildCache();
+    cache.set('mykey', VALID_VALUE, VALID_HASH);
+    const { keys } = cache.getStats();
+    expect(keys).toContain('mykey');
+    expect(keys).not.toContain(`${CACHE_KEY_PREFIX}mykey`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Singleton export
+// ---------------------------------------------------------------------------
+
+describe('wasmBuildCache singleton', () => {
+  afterEach(() => {
+    wasmBuildCache.clear();
+  });
+
+  it('is an instance of WasmBuildCache', () => {
+    expect(wasmBuildCache).toBeInstanceOf(WasmBuildCache);
+  });
+
+  it('can store and retrieve entries', () => {
+    wasmBuildCache.set('singleton-key', VALID_VALUE, VALID_HASH);
+    expect(wasmBuildCache.has('singleton-key')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security edge cases
+// ---------------------------------------------------------------------------
+
+describe('Security edge cases', () => {
+  let cache: WasmBuildCache;
+
+  beforeEach(() => {
+    cache = new WasmBuildCache();
+  });
+
+  it('rejects <script > (with space) injection in value', () => {
+    expect(() =>
+      cache.set(VALID_KEY, '<script >evil()</script >', VALID_HASH)
+    ).toThrow(WasmCacheError);
+  });
+
+  it('rejects onload= event handler injection', () => {
+    expect(() =>
+      cache.set(VALID_KEY, '<img onload=alert(1)>', VALID_HASH)
+    ).toThrow(WasmCacheError);
+  });
+
+  it('rejects key with null byte', () => {
+    expect(() => cache.set('key\0name', VALID_VALUE, VALID_HASH)).toThrow(WasmCacheError);
+  });
+
+  it('rejects key with semicolon', () => {
+    expect(() => cache.set('key;drop', VALID_VALUE, VALID_HASH)).toThrow(WasmCacheError);
+  });
+
+  it('does not leak expired values after eviction', () => {
+    jest.useFakeTimers();
+    cache.set(VALID_KEY, VALID_VALUE, VALID_HASH, { ttlMs: 100 });
+    jest.advanceTimersByTime(500);
+    cache.evictExpired();
+    expect(cache.get(VALID_KEY)).toBeNull();
+    jest.useRealTimers();
+  });
+});

--- a/src/components/wasm_build_pipeline.tsx
+++ b/src/components/wasm_build_pipeline.tsx
@@ -1,0 +1,334 @@
+/**
+ * @title WASM Build Pipeline Caching
+ * @notice Utility for managing WASM build artifact caching in the frontend UI
+ * @dev Provides type-safe, secure caching for WASM build outputs with
+ *      validation, cache invalidation, and developer-friendly error handling.
+ * @author Stellar Raise Contracts Team
+ *
+ * @notice SECURITY: All cache keys and values are validated before storage.
+ *         Dangerous patterns are rejected to prevent cache poisoning attacks.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * @notice Prefix applied to every cache entry to namespace it in storage
+ */
+export const CACHE_KEY_PREFIX = 'wasm_build_cache_';
+
+/**
+ * @notice Default TTL for cached WASM artifacts (24 hours in milliseconds)
+ */
+export const DEFAULT_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * @notice Maximum allowed size for a single cached value (5 MB)
+ */
+export const MAX_CACHE_VALUE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * @notice Regex that valid cache keys must satisfy
+ * @dev Allows alphanumeric characters, hyphens, underscores, and dots only
+ */
+const VALID_KEY_REGEX = /^[a-zA-Z0-9_\-\.]+$/;
+
+/**
+ * @notice Patterns that must never appear in cached values
+ * @dev Guards against script injection via the cache layer
+ */
+const DANGEROUS_VALUE_PATTERNS = [
+  /<script[\s>]/i,
+  /javascript:/i,
+  /data:text\/html/i,
+  /on\w+\s*=/i, // inline event handlers
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * @notice Metadata stored alongside every cached WASM artifact
+ */
+export interface WasmCacheEntry {
+  /** Opaque build hash (e.g. SHA-256 of the WASM binary) */
+  hash: string;
+  /** Unix timestamp (ms) when this entry was written */
+  createdAt: number;
+  /** Unix timestamp (ms) after which this entry is considered stale */
+  expiresAt: number;
+  /** Serialised WASM artifact or build output */
+  value: string;
+  /** Optional human-readable label for debugging */
+  label?: string;
+}
+
+/**
+ * @notice Options accepted by `WasmBuildCache.set`
+ */
+export interface WasmCacheSetOptions {
+  /** Custom TTL in milliseconds; falls back to DEFAULT_CACHE_TTL_MS */
+  ttlMs?: number;
+  /** Human-readable label stored with the entry */
+  label?: string;
+}
+
+/**
+ * @notice Result returned by `WasmBuildCache.getStats`
+ */
+export interface WasmCacheStats {
+  totalEntries: number;
+  expiredEntries: number;
+  validEntries: number;
+  keys: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/**
+ * @title WasmCacheError
+ * @notice Custom error class for WASM cache operations
+ */
+export class WasmCacheError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'WasmCacheError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validator
+// ---------------------------------------------------------------------------
+
+/**
+ * @title WasmCacheValidator
+ * @notice Static helpers for validating cache keys and values
+ */
+export class WasmCacheValidator {
+  /**
+   * @notice Validates a cache key
+   * @param key The raw key string
+   * @throws WasmCacheError if the key is empty or contains invalid characters
+   */
+  static validateKey(key: string): void {
+    if (!key || key.trim().length === 0) {
+      throw new WasmCacheError('Cache key must not be empty.');
+    }
+    if (!VALID_KEY_REGEX.test(key)) {
+      throw new WasmCacheError(
+        `Invalid cache key "${key}". Only alphanumeric characters, hyphens, underscores, and dots are allowed.`
+      );
+    }
+  }
+
+  /**
+   * @notice Validates a cache value for dangerous patterns and size limits
+   * @param value The serialised value to store
+   * @throws WasmCacheError if the value is unsafe or exceeds the size limit
+   */
+  static validateValue(value: string): void {
+    if (new TextEncoder().encode(value).length > MAX_CACHE_VALUE_BYTES) {
+      throw new WasmCacheError(
+        `Cache value exceeds the maximum allowed size of ${MAX_CACHE_VALUE_BYTES} bytes.`
+      );
+    }
+    for (const pattern of DANGEROUS_VALUE_PATTERNS) {
+      if (pattern.test(value)) {
+        throw new WasmCacheError(
+          'Cache value contains a potentially dangerous pattern and was rejected.'
+        );
+      }
+    }
+  }
+
+  /**
+   * @notice Validates a build hash string
+   * @param hash The hash to validate (must be a non-empty hex string)
+   * @throws WasmCacheError if the hash is invalid
+   */
+  static validateHash(hash: string): void {
+    if (!hash || !/^[a-fA-F0-9]+$/.test(hash)) {
+      throw new WasmCacheError(
+        `Invalid build hash "${hash}". Hash must be a non-empty hexadecimal string.`
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cache implementation
+// ---------------------------------------------------------------------------
+
+/**
+ * @title WasmBuildCache
+ * @notice Manages caching of WASM build artifacts for the frontend UI.
+ *
+ * @dev Uses an in-memory Map as the backing store so it works in both browser
+ *      and Node/test environments without requiring Web Storage APIs.
+ *      Swap `_store` for a `localStorage`/`sessionStorage` adapter when
+ *      persistence across page loads is required.
+ */
+export class WasmBuildCache {
+  private _store: Map<string, WasmCacheEntry>;
+
+  constructor() {
+    this._store = new Map();
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * @notice Builds the namespaced storage key
+   */
+  private _buildKey(key: string): string {
+    return `${CACHE_KEY_PREFIX}${key}`;
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /**
+   * @notice Stores a WASM build artifact in the cache
+   * @param key   Unique identifier for this build artifact
+   * @param value Serialised artifact content
+   * @param hash  Build hash used for cache-busting
+   * @param opts  Optional TTL and label overrides
+   * @throws WasmCacheError on validation failure
+   */
+  set(key: string, value: string, hash: string, opts: WasmCacheSetOptions = {}): void {
+    WasmCacheValidator.validateKey(key);
+    WasmCacheValidator.validateValue(value);
+    WasmCacheValidator.validateHash(hash);
+
+    const now = Date.now();
+    const ttl = opts.ttlMs ?? DEFAULT_CACHE_TTL_MS;
+
+    const entry: WasmCacheEntry = {
+      hash,
+      value,
+      createdAt: now,
+      expiresAt: now + ttl,
+      label: opts.label,
+    };
+
+    this._store.set(this._buildKey(key), entry);
+  }
+
+  /**
+   * @notice Retrieves a cached artifact if it exists and has not expired
+   * @param key The cache key
+   * @returns The cache entry, or `null` if missing / expired
+   * @throws WasmCacheError if the key is invalid
+   */
+  get(key: string): WasmCacheEntry | null {
+    WasmCacheValidator.validateKey(key);
+
+    const entry = this._store.get(this._buildKey(key));
+    if (!entry) return null;
+
+    if (Date.now() > entry.expiresAt) {
+      // Evict stale entry eagerly
+      this._store.delete(this._buildKey(key));
+      return null;
+    }
+
+    return entry;
+  }
+
+  /**
+   * @notice Checks whether a valid (non-expired) entry exists for the given key
+   * @param key The cache key
+   * @throws WasmCacheError if the key is invalid
+   */
+  has(key: string): boolean {
+    return this.get(key) !== null;
+  }
+
+  /**
+   * @notice Removes a single entry from the cache
+   * @param key The cache key
+   * @throws WasmCacheError if the key is invalid
+   */
+  delete(key: string): void {
+    WasmCacheValidator.validateKey(key);
+    this._store.delete(this._buildKey(key));
+  }
+
+  /**
+   * @notice Removes all entries from the cache
+   */
+  clear(): void {
+    this._store.clear();
+  }
+
+  /**
+   * @notice Evicts all expired entries from the cache
+   * @returns Number of entries removed
+   */
+  evictExpired(): number {
+    const now = Date.now();
+    let removed = 0;
+    for (const [k, entry] of this._store.entries()) {
+      if (now > entry.expiresAt) {
+        this._store.delete(k);
+        removed++;
+      }
+    }
+    return removed;
+  }
+
+  /**
+   * @notice Returns cache statistics for monitoring / debugging
+   */
+  getStats(): WasmCacheStats {
+    const now = Date.now();
+    let expired = 0;
+    const keys: string[] = [];
+
+    for (const [k, entry] of this._store.entries()) {
+      const rawKey = k.replace(CACHE_KEY_PREFIX, '');
+      keys.push(rawKey);
+      if (now > entry.expiresAt) expired++;
+    }
+
+    return {
+      totalEntries: this._store.size,
+      expiredEntries: expired,
+      validEntries: this._store.size - expired,
+      keys,
+    };
+  }
+
+  /**
+   * @notice Checks whether a cached entry is still valid for the given hash.
+   *         Returns false if the entry is missing, expired, or the hash differs.
+   * @param key  The cache key
+   * @param hash The expected build hash
+   */
+  isValid(key: string, hash: string): boolean {
+    WasmCacheValidator.validateKey(key);
+    WasmCacheValidator.validateHash(hash);
+
+    const entry = this.get(key);
+    return entry !== null && entry.hash === hash;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Singleton helper
+// ---------------------------------------------------------------------------
+
+/**
+ * @notice Module-level singleton cache instance
+ * @dev Import and use this directly for the common case.
+ */
+export const wasmBuildCache = new WasmBuildCache();
+
+export default WasmBuildCache;


### PR DESCRIPTION
## Summary

Implements the WASM build pipeline caching utility for the frontend UI, improving developer experience by avoiding redundant WASM rebuilds and providing a reliable, hash-based cache invalidation mechanism.

## Changes

- `src/components/wasm_build_pipeline.tsx` — Core caching implementation with `WasmBuildCache`, `WasmCacheValidator`, typed interfaces, and a module-level singleton export.
- `src/components/wasm_build_pipeline.test.tsx` — Comprehensive test suite covering happy paths, TTL expiry, hash invalidation, bulk eviction, cache stats, and security edge cases (script injection, oversized payloads, invalid keys/hashes).
- `src/components/wasm_build_pipeline.md` — Full API reference and usage documentation with NatSpec-style comments throughout the source.

## Security

All cache keys and values are validated before storage:
- Keys must match `/^[a-zA-Z0-9_\-\.]+$/`
- Values are scanned for `<script>`, `javascript:`, `data:text/html`, and inline event handlers
- Values are capped at 5 MB to prevent memory exhaustion

## Testing

Run tests with:
```bash
npx jest src/components/wasm_build_pipeline.test.tsx --coverage

closes #361 
