### PR TITLE
feat: implement create-documentation-for-react-submit-button-componen…

### DIFF
--- a/frontend/components/react_submit_button.md
+++ b/frontend/components/react_submit_button.md
@@ -1,138 +1,158 @@
-# SubmitButton Component
+# React Submit Button — Dependencies
 
-Addresses [GitHub Issue #359](https://github.com/Crowdfunding-DApp/stellar-raise-contracts/issues/359).
-
-A robust, accessible React submit button with full state management for crowdfunding transaction flows.
+Documents the runtime dependencies, peer requirements, dev toolchain, and upgrade guidance for `react_submit_button.tsx`.
 
 ---
 
-## Files
+## Runtime Dependencies
 
-| File | Purpose |
-|------|---------|
-| `react_submit_button.tsx` | Component implementation |
-| `react_submit_button.test.tsx` | Test suite (≥ 95% coverage) |
-| `react_submit_button.md` | This document |
+The component has **zero production dependencies beyond React itself**.
+
+| Package | Version range | Role | Justification |
+|---------|--------------|------|---------------|
+| `react` | `^19.0.0` | Peer — JSX, hooks (`useState`) | Required for component rendering |
+| `react-dom` | `^19.0.0` | Peer — DOM rendering | Required by the consuming app; not imported directly |
+
+No third-party UI libraries, animation libraries, or utility packages are imported. This keeps the bundle contribution of this component to a minimum and eliminates transitive dependency risk.
 
 ---
 
-## States
+## Dev / Test Dependencies
 
-The button moves through a deterministic state machine:
+| Package | Version range | Role |
+|---------|--------------|------|
+| `@testing-library/react` | `^16.0.0` | `render`, `screen`, `fireEvent`, `act` |
+| `@testing-library/jest-dom` | `^6.0.0` | Extended matchers (used via `jest.setup.ts`) |
+| `@testing-library/user-event` | `^14.0.0` | Available for future interaction tests |
+| `jest` | `^30.0.0` | Test runner |
+| `jest-environment-jsdom` | `^30.0.0` | DOM environment for React tests |
+| `ts-jest` | `^29.0.0` | TypeScript transform for Jest |
+| `typescript` | `^5.0.0` | Type checking |
+| `@types/react` | `^19.0.0` | React type definitions |
+| `@types/jest` | `^30.0.0` | Jest type definitions |
+
+All dev dependencies are declared in the workspace `package.json` and are not shipped to production.
+
+---
+
+## Peer Dependency Requirements
+
+### React 19
+
+The component uses:
+
+- `useState` — local in-flight submission guard
+- `React.MouseEvent<HTMLButtonElement>` — typed click handler
+- `React.CSSProperties` — inline style typing
+- `react-jsx` transform — no explicit `React` import needed at call sites
+
+React 18 is also compatible. The only React 19 feature used is the `react-jsx` automatic JSX transform, which was introduced in React 17. **Minimum supported React version: 17**.
+
+### TypeScript 4.7+
+
+The component uses:
+
+- Const type parameters (TypeScript 5.0) — not used; compatible with TS 4.7+
+- Template literal types — not used
+- Strict union types and `Record<K, V>` — available since TS 4.1
+
+**Minimum supported TypeScript version: 4.7**.
+
+---
+
+## What the Component Does NOT Depend On
+
+| Excluded dependency | Reason |
+|--------------------|--------|
+| `classnames` / `clsx` | Class logic is a single optional prop passthrough |
+| `styled-components` / `emotion` | Styles are inline `React.CSSProperties` constants |
+| `framer-motion` / `react-spring` | Transitions use CSS `transition` property only |
+| `react-hook-form` | Component is form-library agnostic |
+| `zustand` / `redux` | State is fully controlled by the parent via the `state` prop |
+| `lodash` | No utility functions needed |
+| `uuid` | No ID generation needed |
+
+Keeping the dependency surface minimal reduces:
+- Bundle size impact on the consuming app
+- Supply-chain attack surface
+- Version conflict risk in monorepos
+
+---
+
+## Dependency Graph
 
 ```
-idle ──click──► loading ──resolve──► success ──resetDelay──► idle
-                        └──reject──► error   ──resetDelay──► idle
-```
+react_submit_button.tsx
+└── react          (peer, runtime)
+    └── react-dom  (peer, runtime — consuming app only)
 
-| State | Visual | Interaction | Native `disabled` |
-|-------|--------|-------------|-------------------|
-| `idle` | Indigo | Clickable | No |
-| `loading` | Light indigo + spinner | Blocked | Yes |
-| `success` | Green + ✓ | Blocked | Yes |
-| `error` | Red + retry label | Clickable (retry) | No |
-| `disabled` | Grey, 60% opacity | Blocked | Yes |
-
----
-
-## Usage
-
-```tsx
-import SubmitButton from "../components/react_submit_button";
-
-<SubmitButton
-  label="Fund Campaign"
-  onClick={async () => {
-    await submitTransaction();
-  }}
-/>
-```
-
-### With all options
-
-```tsx
-<SubmitButton
-  label="Contribute"
-  onClick={handleContribute}
-  disabled={!walletConnected}
-  resetDelay={3000}
-  type="button"
-  data-testid="contribute-btn"
-/>
+react_submit_button.test.tsx
+├── react                        (peer)
+├── @testing-library/react       (dev)
+├── @testing-library/jest-dom    (dev, via jest.setup.ts)
+└── react_submit_button.tsx      (local)
 ```
 
 ---
 
-## Props
+## Version Pinning Policy
 
-| Prop | Type | Default | Description |
-|------|------|---------|-------------|
-| `label` | `string` | required | Button text in idle/disabled states |
-| `onClick` | `() => Promise<void>` | required | Async handler; rejection triggers error state |
-| `disabled` | `boolean` | `false` | External disabled flag |
-| `resetDelay` | `number` | `2500` | ms before auto-reset from success/error |
-| `type` | `"submit" \| "button" \| "reset"` | `"submit"` | HTML button type |
-| `style` | `React.CSSProperties` | — | Extra inline styles |
-| `data-testid` | `string` | — | Test selector |
+The workspace `package.json` uses caret ranges (`^`) for all dependencies. This allows non-breaking minor and patch updates while preventing automatic major version upgrades.
+
+For production deployments, pin exact versions in `package-lock.json` (already committed) and run `npm ci` rather than `npm install` to guarantee reproducible installs.
 
 ---
 
-## Security Assumptions
+## Upgrading React
 
-### Double-submit prevention
-Clicks are silently ignored in `loading`, `success`, and `disabled` states. This prevents duplicate blockchain transactions (double-spend) when a user clicks repeatedly while a transaction is in-flight.
+### React 17 → 18
 
-### No HTML injection
-The `label` prop and all state labels are rendered as React text nodes, never via `dangerouslySetInnerHTML`. XSS via the label prop is not possible.
+No changes required. The component does not use `ReactDOM.render` (removed in React 18) or any deprecated lifecycle methods.
 
-### No user-controlled styles
-Background colours and cursors are sourced exclusively from the `STATE_CONFIG` constant. No user-supplied strings are interpolated into CSS values.
+### React 18 → 19
 
-### Timer cleanup
-The reset timer is cleared on component unmount via a `useEffect` cleanup function, preventing state updates on unmounted components and potential memory leaks.
+No changes required. The component does not use:
+- `ReactDOM.render` (removed in 18)
+- `act` from `react-dom/test-utils` (moved to `react` in 19 — tests already import from `@testing-library/react`)
+- Concurrent features that changed API between 18 and 19
 
-### Negative `resetDelay` clamped
-`Math.max(0, resetDelay)` ensures a negative value cannot cause unexpected behaviour.
+### Upgrading `@testing-library/react`
+
+The test suite uses `render`, `screen`, `fireEvent`, and `act` — all stable APIs present since `@testing-library/react` v13. No breaking changes are expected through v16.
+
+---
+
+## Security Assumptions Related to Dependencies
+
+1. **No `dangerouslySetInnerHTML`** — the component never uses this API, so XSS via label content is not possible regardless of React version.
+2. **No dynamic `import()`** — the component is statically bundled; no code-splitting attack surface.
+3. **No network calls** — the component is purely presentational; it emits events to the parent and renders state. No fetch, axios, or WebSocket dependency.
+4. **Inline styles only** — no CSS-in-JS runtime that could be exploited via style injection. All colour values are hardcoded constants in `STATE_STYLES`.
 
 ---
 
 ## NatSpec-style Reference
 
-### `SubmitButton`
-- **@notice** Accessible submit button with idle / loading / success / error / disabled states.
-- **@param** `label` — Text shown in idle and disabled states.
-- **@param** `onClick` — Async handler; must return `Promise<void>`. Rejection triggers error state.
-- **@param** `disabled` — When `true`, maps to the `disabled` state and blocks interaction.
-- **@param** `resetDelay` — Milliseconds before auto-reset. Default `2500`. Clamped to `≥ 0`.
-- **@security** Clicks are ignored in non-idle/non-error states (double-submit protection).
-- **@security** Timer is cleaned up on unmount (memory-leak protection).
-
-### `STATE_CONFIG`
-- **@notice** Centralised visual configuration for each button state.
-- **@dev** All colours are hardcoded hex values — no dynamic CSS injection.
-
-### `ButtonState`
-- **@notice** Union type: `"idle" | "loading" | "success" | "error" | "disabled"`.
+### Dependency contract
+- **@notice** `react_submit_button.tsx` has one runtime peer dependency: `react ≥ 17`.
+- **@dev** All other imports are local types and constants — no third-party runtime packages.
+- **@security** Zero third-party runtime dependencies eliminates transitive supply-chain risk for this component.
 
 ---
 
-## Test Coverage
-
-Run with:
+## Running Tests
 
 ```bash
-npm test -- --testPathPattern=react_submit_button --coverage
+# Run with coverage report
+npx jest --testPathPatterns=react_submit_button --coverage
+
+# Watch mode during development
+npm run test:watch -- --testPathPatterns=react_submit_button
 ```
 
-The suite covers:
+### Latest test output
 
-- `STATE_CONFIG` completeness and correctness (14 tests)
-- `ButtonState` type validation (3 tests)
-- `SubmitButtonProps` interface (6 tests)
-- State transition logic — all paths (8 tests)
-- Security: double-submit prevention (3 tests)
-- Accessibility attributes (5 tests)
-- Display label logic including XSS edge case (6 tests)
-- `resetDelay` edge cases (3 tests)
-- Style configuration (3 tests)
-- Integration: full lifecycle simulations (2 tests)
+```
+Tests:    51 passed, 51 total
+Coverage: 97.67% statements | 96.87% branches | 100% functions | 100% lines
+```

--- a/frontend/components/react_submit_button.test.tsx
+++ b/frontend/components/react_submit_button.test.tsx
@@ -1,209 +1,374 @@
 /**
- * @title React Submit Button Security and Reliability Tests
- * @notice Covers label safety, state transitions, and interaction blocking rules.
+ * @title React Submit Button — Comprehensive Test Suite
+ * @notice Covers label safety, state transitions, interaction blocking,
+ *         accessibility attributes, and component rendering.
+ * @dev Targets ≥ 95% coverage of react_submit_button.tsx.
  */
-import {
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import ReactSubmitButton, {
+  ALLOWED_TRANSITIONS,
   isSubmitButtonBusy,
   isSubmitButtonInteractionBlocked,
   isValidSubmitButtonStateTransition,
   normalizeSubmitButtonLabel,
-  resolveSafeSubmitButtonState,
- * @title React Submit Button Tests
- * @notice Validates state transitions, accessibility flags, and security-aware label handling.
- */
-import {
-  isSubmitButtonBusy,
-  isSubmitButtonDisabled,
   resolveSubmitButtonLabel,
+  resolveSafeSubmitButtonState,
+  type ReactSubmitButtonProps,
   type SubmitButtonLabels,
   type SubmitButtonState,
 } from "./react_submit_button";
 
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderBtn(props: Partial<ReactSubmitButtonProps> = {}) {
+  const { container } = render(<ReactSubmitButton state="idle" {...props} />);
+  return container.querySelector("button") as HTMLButtonElement;
+}
+
+const ALL_STATES: SubmitButtonState[] = ["idle", "submitting", "success", "error", "disabled"];
+
+// ── normalizeSubmitButtonLabel ────────────────────────────────────────────────
+
 describe("normalizeSubmitButtonLabel", () => {
   it("returns fallback for non-string values", () => {
     expect(normalizeSubmitButtonLabel(undefined, "Submit")).toBe("Submit");
+    expect(normalizeSubmitButtonLabel(null, "Submit")).toBe("Submit");
     expect(normalizeSubmitButtonLabel(404, "Submit")).toBe("Submit");
     expect(normalizeSubmitButtonLabel({}, "Submit")).toBe("Submit");
+    expect(normalizeSubmitButtonLabel(true, "Submit")).toBe("Submit");
   });
 
-  it("returns fallback for empty or whitespace labels", () => {
+  it("returns fallback for empty or whitespace-only strings", () => {
     expect(normalizeSubmitButtonLabel("", "Submit")).toBe("Submit");
-    expect(normalizeSubmitButtonLabel("   \n\t", "Submit")).toBe("Submit");
+    expect(normalizeSubmitButtonLabel("   ", "Submit")).toBe("Submit");
+    expect(normalizeSubmitButtonLabel("\n\t", "Submit")).toBe("Submit");
   });
 
-  it("removes control characters and normalizes whitespace", () => {
-    const dirtyLabel = "Pay\u0000\u0008\n   Now";
-    expect(normalizeSubmitButtonLabel(dirtyLabel, "Submit")).toBe("Pay Now");
+  it("strips control characters and normalizes whitespace", () => {
+    expect(normalizeSubmitButtonLabel("Pay\u0000Now", "Submit")).toBe("Pay Now");
+    expect(normalizeSubmitButtonLabel("Pay\u0008\u001FNow", "Submit")).toBe("Pay Now");
+    expect(normalizeSubmitButtonLabel("Pay   \n   Now", "Submit")).toBe("Pay Now");
   });
 
-  it("truncates labels above the maximum bound", () => {
-    const longLabel = "A".repeat(200);
-    const normalized = normalizeSubmitButtonLabel(longLabel, "Submit");
+  it("returns the label unchanged when within the 80-char limit", () => {
+    const label = "A".repeat(80);
+    expect(normalizeSubmitButtonLabel(label, "Submit")).toBe(label);
+  });
 
-    expect(normalized).toHaveLength(80);
-    expect(normalized.endsWith("...")).toBe(true);
+  it("truncates labels exceeding 80 characters with ellipsis", () => {
+    const long = "A".repeat(200);
+    const result = normalizeSubmitButtonLabel(long, "Submit");
+    expect(result).toHaveLength(80);
+    expect(result.endsWith("...")).toBe(true);
+  });
+
+  it("preserves hostile markup-like text as a plain string", () => {
+    const xss = "<img src=x onerror=alert(1) />";
+    // Security: React renders this as text, not HTML.
+    expect(normalizeSubmitButtonLabel(xss, "Submit")).toBe(xss);
   });
 });
 
+// ── resolveSubmitButtonLabel ──────────────────────────────────────────────────
+
 describe("resolveSubmitButtonLabel", () => {
-  it("returns defaults for every known state", () => {
-    const states: SubmitButtonState[] = ["idle", "submitting", "success", "error", "disabled"];
-    const labels = states.map((state) => resolveSubmitButtonLabel(state));
-
-    expect(labels).toEqual(["Submit", "Submitting...", "Submitted", "Try Again", "Submit Disabled"]);
+  it("returns correct defaults for every state", () => {
+    const expected = ["Submit", "Submitting...", "Submitted", "Try Again", "Submit Disabled"];
+    expect(ALL_STATES.map((s) => resolveSubmitButtonLabel(s))).toEqual(expected);
   });
 
-  it("uses sanitized custom labels", () => {
-    const customLabels: SubmitButtonLabels = {
-      success: "  Campaign submitted successfully  ",
-    };
-
-    expect(resolveSubmitButtonLabel("success", customLabels)).toBe("Campaign submitted successfully");
-  });
-
-  it("keeps hostile markup-like text as inert string content", () => {
-    const hostile = "<img src=x onerror=alert(1) />";
-    const labels: SubmitButtonLabels = { error: hostile };
-
-    // Security assumption: React escapes text nodes, so this remains plain text content.
-describe("resolveSubmitButtonLabel", () => {
-  it("returns default labels for every known state", () => {
-    const states: SubmitButtonState[] = ["idle", "submitting", "success", "error", "disabled"];
-    const output = states.map((state) => resolveSubmitButtonLabel(state));
-
-    expect(output).toEqual(["Submit", "Submitting...", "Submitted", "Try Again", "Submit Disabled"]);
-  });
-
-  it("uses custom labels when valid", () => {
+  it("uses valid custom labels", () => {
     const labels: SubmitButtonLabels = {
-      idle: "Send Now",
-      submitting: "Please wait",
-      success: "Done",
+      idle: "Fund Campaign",
+      submitting: "Funding...",
+      success: "Funded!",
       error: "Retry",
       disabled: "Locked",
     };
-
-    expect(resolveSubmitButtonLabel("idle", labels)).toBe("Send Now");
-    expect(resolveSubmitButtonLabel("submitting", labels)).toBe("Please wait");
-    expect(resolveSubmitButtonLabel("success", labels)).toBe("Done");
-    expect(resolveSubmitButtonLabel("error", labels)).toBe("Retry");
-    expect(resolveSubmitButtonLabel("disabled", labels)).toBe("Locked");
+    ALL_STATES.forEach((s) => {
+      expect(resolveSubmitButtonLabel(s, labels)).toBe(labels[s]);
+    });
   });
 
-  it("falls back to defaults for empty or whitespace labels", () => {
-    const labels: SubmitButtonLabels = {
-      idle: "",
-      submitting: "   ",
-    };
-
+  it("falls back to defaults for empty or whitespace custom labels", () => {
+    const labels: SubmitButtonLabels = { idle: "", submitting: "   " };
     expect(resolveSubmitButtonLabel("idle", labels)).toBe("Submit");
     expect(resolveSubmitButtonLabel("submitting", labels)).toBe("Submitting...");
   });
 
-  it("trims custom labels and limits overly long labels", () => {
-    const veryLongLabel = `${"A".repeat(90)} trailing text`;
-    const labels: SubmitButtonLabels = {
-      success: `   ${veryLongLabel}   `,
-    };
-
-    const resolved = resolveSubmitButtonLabel("success", labels);
-    expect(resolved.length).toBe(80);
-    expect(resolved.endsWith("...")).toBe(true);
-  });
-
-  it("keeps potentially hostile text as plain label content", () => {
-    const hostile = "<img src=x onerror=alert(1) />";
-    const labels: SubmitButtonLabels = { error: hostile };
-
-    // Security note: React renders strings as text, not executable HTML.
-    expect(resolveSubmitButtonLabel("error", labels)).toBe(hostile);
+  it("trims and truncates oversized custom labels", () => {
+    const labels: SubmitButtonLabels = { success: `   ${"A".repeat(90)}   ` };
+    const result = resolveSubmitButtonLabel("success", labels);
+    expect(result).toHaveLength(80);
+    expect(result.endsWith("...")).toBe(true);
   });
 });
+
+// ── isValidSubmitButtonStateTransition ───────────────────────────────────────
 
 describe("isValidSubmitButtonStateTransition", () => {
-  it("allows expected forward transitions", () => {
-    expect(isValidSubmitButtonStateTransition("idle", "submitting")).toBe(true);
-    expect(isValidSubmitButtonStateTransition("submitting", "success")).toBe(true);
-    expect(isValidSubmitButtonStateTransition("submitting", "error")).toBe(true);
-    expect(isValidSubmitButtonStateTransition("error", "submitting")).toBe(true);
-    expect(isValidSubmitButtonStateTransition("disabled", "idle")).toBe(true);
+  it("allows all transitions defined in ALLOWED_TRANSITIONS", () => {
+    for (const [from, targets] of Object.entries(ALLOWED_TRANSITIONS) as [SubmitButtonState, SubmitButtonState[]][]) {
+      for (const to of targets) {
+        expect(isValidSubmitButtonStateTransition(from, to)).toBe(true);
+      }
+    }
   });
 
-  it("allows same-state transitions (idempotent updates)", () => {
-    expect(isValidSubmitButtonStateTransition("idle", "idle")).toBe(true);
-    expect(isValidSubmitButtonStateTransition("success", "success")).toBe(true);
+  it("allows same-state transitions (idempotent)", () => {
+    ALL_STATES.forEach((s) => {
+      expect(isValidSubmitButtonStateTransition(s, s)).toBe(true);
+    });
   });
 
-  it("blocks invalid transitions", () => {
+  it("blocks transitions not in the allowed map", () => {
     expect(isValidSubmitButtonStateTransition("idle", "success")).toBe(false);
+    expect(isValidSubmitButtonStateTransition("idle", "error")).toBe(false);
     expect(isValidSubmitButtonStateTransition("success", "error")).toBe(false);
+    expect(isValidSubmitButtonStateTransition("success", "submitting")).toBe(false);
     expect(isValidSubmitButtonStateTransition("disabled", "submitting")).toBe(false);
+    expect(isValidSubmitButtonStateTransition("disabled", "success")).toBe(false);
   });
 });
+
+// ── resolveSafeSubmitButtonState ─────────────────────────────────────────────
 
 describe("resolveSafeSubmitButtonState", () => {
-  it("returns requested state when transition is valid", () => {
+  it("returns requested state when transition is valid (strict)", () => {
     expect(resolveSafeSubmitButtonState("submitting", "idle", true)).toBe("submitting");
+    expect(resolveSafeSubmitButtonState("success", "submitting", true)).toBe("success");
+    expect(resolveSafeSubmitButtonState("error", "submitting", true)).toBe("error");
   });
 
-  it("falls back to previous state for invalid strict transitions", () => {
+  it("falls back to previousState for invalid transitions in strict mode", () => {
     expect(resolveSafeSubmitButtonState("success", "idle", true)).toBe("idle");
+    expect(resolveSafeSubmitButtonState("error", "success", true)).toBe("success");
+    expect(resolveSafeSubmitButtonState("submitting", "disabled", true)).toBe("disabled");
   });
 
-  it("accepts requested state when strict mode is disabled", () => {
+  it("accepts any state when strict mode is disabled", () => {
     expect(resolveSafeSubmitButtonState("success", "idle", false)).toBe("success");
+    expect(resolveSafeSubmitButtonState("error", "success", false)).toBe("error");
   });
 
-  it("accepts requested state when previous state is unavailable", () => {
+  it("accepts requested state when previousState is absent", () => {
     expect(resolveSafeSubmitButtonState("error", undefined, true)).toBe("error");
+    expect(resolveSafeSubmitButtonState("success", undefined, true)).toBe("success");
+  });
+
+  it("defaults strictTransitions to true", () => {
+    // idle → success is invalid; should fall back to idle
+    expect(resolveSafeSubmitButtonState("success", "idle")).toBe("idle");
   });
 });
 
-describe("interaction and busy guards", () => {
-  it("blocks interaction for disabled and submitting states", () => {
+// ── isSubmitButtonInteractionBlocked ─────────────────────────────────────────
+
+describe("isSubmitButtonInteractionBlocked", () => {
+  it("blocks interaction for submitting and disabled states", () => {
     expect(isSubmitButtonInteractionBlocked("submitting")).toBe(true);
     expect(isSubmitButtonInteractionBlocked("disabled")).toBe(true);
   });
 
-  it("blocks interaction when explicit or local flags are set", () => {
-    expect(isSubmitButtonInteractionBlocked("idle", true, false)).toBe(true);
+  it("blocks when explicit disabled flag is set", () => {
+    expect(isSubmitButtonInteractionBlocked("idle", true)).toBe(true);
+    expect(isSubmitButtonInteractionBlocked("error", true)).toBe(true);
+  });
+
+  it("blocks when locally submitting", () => {
     expect(isSubmitButtonInteractionBlocked("idle", false, true)).toBe(true);
   });
 
-  it("allows interaction for active states when flags are clear", () => {
+  it("allows interaction for active states with no flags", () => {
     expect(isSubmitButtonInteractionBlocked("idle", false, false)).toBe(false);
     expect(isSubmitButtonInteractionBlocked("error", false, false)).toBe(false);
     expect(isSubmitButtonInteractionBlocked("success", false, false)).toBe(false);
   });
-
-  it("sets busy only for submitting or local in-flight execution", () => {
-    expect(isSubmitButtonBusy("submitting", false)).toBe(true);
-    expect(isSubmitButtonBusy("idle", true)).toBe(true);
-    expect(isSubmitButtonBusy("idle", false)).toBe(false);
-describe("isSubmitButtonDisabled", () => {
-  it("returns true for submitting and disabled states", () => {
-    expect(isSubmitButtonDisabled("submitting")).toBe(true);
-    expect(isSubmitButtonDisabled("disabled")).toBe(true);
-  });
-
-  it("returns false for active states when disabled flag is not set", () => {
-    expect(isSubmitButtonDisabled("idle")).toBe(false);
-    expect(isSubmitButtonDisabled("success")).toBe(false);
-    expect(isSubmitButtonDisabled("error")).toBe(false);
-  });
-
-  it("respects explicit disabled override", () => {
-    expect(isSubmitButtonDisabled("idle", true)).toBe(true);
-    expect(isSubmitButtonDisabled("success", true)).toBe(true);
-  });
 });
+
+// ── isSubmitButtonBusy ────────────────────────────────────────────────────────
 
 describe("isSubmitButtonBusy", () => {
   it("is true only while submitting", () => {
     expect(isSubmitButtonBusy("submitting")).toBe(true);
-    expect(isSubmitButtonBusy("idle")).toBe(false);
-    expect(isSubmitButtonBusy("success")).toBe(false);
-    expect(isSubmitButtonBusy("error")).toBe(false);
-    expect(isSubmitButtonBusy("disabled")).toBe(false);
+  });
+
+  it("is true when locally submitting regardless of state", () => {
+    expect(isSubmitButtonBusy("idle", true)).toBe(true);
+    expect(isSubmitButtonBusy("error", true)).toBe(true);
+  });
+
+  it("is false for all non-submitting states with no local flag", () => {
+    const nonSubmitting: SubmitButtonState[] = ["idle", "success", "error", "disabled"];
+    nonSubmitting.forEach((s) => {
+      expect(isSubmitButtonBusy(s, false)).toBe(false);
+    });
+  });
+});
+
+// ── ReactSubmitButton — rendering ────────────────────────────────────────────
+
+describe("ReactSubmitButton rendering", () => {
+  it("renders a button element", () => {
+    const btn = renderBtn();
+    expect(btn.tagName).toBe("BUTTON");
+  });
+
+  it("displays the resolved label as text content", () => {
+    renderBtn({ state: "idle" });
+    expect(screen.getByText("Submit")).toBeTruthy();
+  });
+
+  it("displays custom label override", () => {
+    renderBtn({ state: "idle", labels: { idle: "Fund Campaign" } });
+    expect(screen.getByText("Fund Campaign")).toBeTruthy();
+  });
+
+  it("sets data-state to the resolved state", () => {
+    ALL_STATES.forEach((s) => {
+      const btn = renderBtn({ state: s });
+      expect(btn.getAttribute("data-state")).toBe(s);
+    });
+  });
+
+  it("defaults type to 'button'", () => {
+    expect(renderBtn().type).toBe("button");
+  });
+
+  it("respects explicit type prop", () => {
+    expect(renderBtn({ type: "submit" }).type).toBe("submit");
+    expect(renderBtn({ type: "reset" }).type).toBe("reset");
+  });
+
+  it("applies custom className", () => {
+    const btn = renderBtn({ className: "my-btn" });
+    expect(btn.className).toContain("my-btn");
+  });
+
+  it("sets the id attribute", () => {
+    const btn = renderBtn({ id: "contribute-btn" });
+    expect(btn.id).toBe("contribute-btn");
+  });
+});
+
+// ── ReactSubmitButton — disabled / blocked states ────────────────────────────
+
+describe("ReactSubmitButton disabled behavior", () => {
+  it("is disabled in submitting state", () => {
+    expect(renderBtn({ state: "submitting" }).disabled).toBe(true);
+  });
+
+  it("is disabled in disabled state", () => {
+    expect(renderBtn({ state: "disabled" }).disabled).toBe(true);
+  });
+
+  it("is disabled when disabled prop is true", () => {
+    expect(renderBtn({ disabled: true }).disabled).toBe(true);
+  });
+
+  it("is NOT disabled in idle, success, or error states by default", () => {
+    expect(renderBtn({ state: "idle" }).disabled).toBe(false);
+    expect(renderBtn({ state: "success" }).disabled).toBe(false);
+    expect(renderBtn({ state: "error" }).disabled).toBe(false);
+  });
+});
+
+// ── ReactSubmitButton — accessibility ────────────────────────────────────────
+
+describe("ReactSubmitButton accessibility", () => {
+  it("has aria-live='polite'", () => {
+    expect(renderBtn().getAttribute("aria-live")).toBe("polite");
+  });
+
+  it("sets aria-busy='true' while submitting", () => {
+    expect(renderBtn({ state: "submitting" }).getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("sets aria-busy='false' for non-submitting states", () => {
+    const nonBusy: SubmitButtonState[] = ["idle", "success", "error", "disabled"];
+    nonBusy.forEach((s) => {
+      expect(renderBtn({ state: s }).getAttribute("aria-busy")).toBe("false");
+    });
+  });
+
+  it("sets aria-label to the resolved label", () => {
+    expect(renderBtn({ state: "idle" }).getAttribute("aria-label")).toBe("Submit");
+    expect(renderBtn({ state: "error" }).getAttribute("aria-label")).toBe("Try Again");
+  });
+});
+
+// ── ReactSubmitButton — click handling ───────────────────────────────────────
+
+describe("ReactSubmitButton click handling", () => {
+  it("fires onClick in idle state", () => {
+    const onClick = jest.fn();
+    fireEvent.click(renderBtn({ onClick }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onClick in error state (retry)", () => {
+    const onClick = jest.fn();
+    fireEvent.click(renderBtn({ state: "error", onClick }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire onClick in submitting state", () => {
+    const onClick = jest.fn();
+    fireEvent.click(renderBtn({ state: "submitting", onClick }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onClick in disabled state", () => {
+    const onClick = jest.fn();
+    fireEvent.click(renderBtn({ state: "disabled", onClick }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("does NOT fire onClick when disabled prop is true", () => {
+    const onClick = jest.fn();
+    fireEvent.click(renderBtn({ disabled: true, onClick }));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("handles async onClick without throwing", async () => {
+    const onClick = jest.fn().mockResolvedValue(undefined);
+    const { container } = render(<ReactSubmitButton state="idle" onClick={onClick} />);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not propagate errors from a rejected async onClick", async () => {
+    const onClick = jest.fn().mockRejectedValue(new Error("tx failed"));
+    const { container } = render(<ReactSubmitButton state="idle" onClick={onClick} />);
+    const btn = container.querySelector("button") as HTMLButtonElement;
+    await act(async () => {
+      fireEvent.click(btn);
+    });
+    // If we reach here without throwing, the component swallowed the rejection correctly.
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── ReactSubmitButton — strict transition enforcement ────────────────────────
+
+describe("ReactSubmitButton strict transitions", () => {
+  it("renders previousState when transition is invalid in strict mode", () => {
+    // idle → success is not allowed; should render idle
+    const btn = renderBtn({ state: "success", previousState: "idle", strictTransitions: true });
+    expect(btn.getAttribute("data-state")).toBe("idle");
+  });
+
+  it("renders requested state when transition is valid in strict mode", () => {
+    const btn = renderBtn({ state: "submitting", previousState: "idle", strictTransitions: true });
+    expect(btn.getAttribute("data-state")).toBe("submitting");
+  });
+
+  it("renders requested state when strict mode is disabled", () => {
+    const btn = renderBtn({ state: "success", previousState: "idle", strictTransitions: false });
+    expect(btn.getAttribute("data-state")).toBe("success");
   });
 });

--- a/frontend/components/react_submit_button.tsx
+++ b/frontend/components/react_submit_button.tsx
@@ -1,22 +1,29 @@
-import React, { useMemo, useState } from "react";
+import React, { useState } from "react";
 
 /**
  * @title React Submit Button States
- * @notice Typed submit button state model with secure label handling and reliability guards.
- * @dev The component intentionally prefers safe defaults to reduce accidental double submits.
-import React from "react";
+ * @notice Typed submit button with a strict state machine, safe label handling,
+ *         double-submit prevention, and ARIA accessibility semantics.
+ * @dev Labels are rendered as React text nodes — no dangerouslySetInnerHTML path.
+ *      Interaction is blocked while submitting to prevent duplicate blockchain transactions.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 /**
- * @title React Submit Button Component States
- * @notice Centralized submit-button state model for consistent UX and safe defaults.
- * @dev Uses strict union types and deterministic state mapping to reduce misuse.
+ * @notice All supported visual/interaction states.
+ * @dev Allowed transitions:
+ *   idle        → submitting | disabled
+ *   submitting  → success | error | disabled
+ *   success     → idle | disabled
+ *   error       → idle | submitting | disabled
+ *   disabled    → idle
  */
 export type SubmitButtonState = "idle" | "submitting" | "success" | "error" | "disabled";
 
 /**
- * @title Submit Button Labels
- * @notice Optional override labels for each supported state.
- * @notice Optional custom labels for each user-visible state.
+ * @notice Optional per-state label overrides.
+ * @dev Values are normalized: non-strings, empty strings, and control characters are rejected.
  */
 export interface SubmitButtonLabels {
   idle?: string;
@@ -27,8 +34,16 @@ export interface SubmitButtonLabels {
 }
 
 /**
- * @title React Submit Button Props
- * @notice Contract for state, label overrides, and interaction behavior.
+ * @notice Props accepted by ReactSubmitButton.
+ * @param state          Current button state (required).
+ * @param previousState  Previous state used for strict transition validation.
+ * @param strictTransitions  When true, invalid state jumps fall back to previousState.
+ * @param labels         Optional label overrides per state.
+ * @param onClick        Async-safe click handler; blocked while submitting/disabled.
+ * @param className      Additional CSS class.
+ * @param id             HTML id attribute.
+ * @param type           HTML button type. Default: "button".
+ * @param disabled       External disabled override.
  */
 export interface ReactSubmitButtonProps {
   state: SubmitButtonState;
@@ -36,18 +51,16 @@ export interface ReactSubmitButtonProps {
   strictTransitions?: boolean;
   labels?: SubmitButtonLabels;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void | Promise<void>;
- * @title Submit Button Props
- * @notice Defines behavior, labeling, and accessibility requirements.
- */
-export interface ReactSubmitButtonProps {
-  state: SubmitButtonState;
-  labels?: SubmitButtonLabels;
-  onClick?: () => void | Promise<void>;
   className?: string;
   id?: string;
-  type?: "button" | "submit";
+  type?: "button" | "submit" | "reset";
   disabled?: boolean;
 }
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const MAX_LABEL_LENGTH = 80;
+const CONTROL_CHAR_RE = /[\u0000-\u001F\u007F]/g;
 
 const DEFAULT_LABELS: Required<SubmitButtonLabels> = {
   idle: "Submit",
@@ -57,137 +70,17 @@ const DEFAULT_LABELS: Required<SubmitButtonLabels> = {
   disabled: "Submit Disabled",
 };
 
-const MAX_LABEL_LENGTH = 80;
-const CONTROL_CHARACTER_REGEX = /[\u0000-\u001F\u007F]/g;
-
-const ALLOWED_STATE_TRANSITIONS: Record<SubmitButtonState, SubmitButtonState[]> = {
+/**
+ * @notice Allowed state transitions.
+ * @dev Centralised here so both the guard and tests share one source of truth.
+ */
+export const ALLOWED_TRANSITIONS: Record<SubmitButtonState, SubmitButtonState[]> = {
   idle: ["submitting", "disabled"],
   submitting: ["success", "error", "disabled"],
   success: ["idle", "disabled"],
   error: ["idle", "submitting", "disabled"],
   disabled: ["idle"],
 };
-
-/**
- * @title Label Normalizer
- * @notice Enforces string-only, bounded, and readable labels.
- * @dev Removes control characters and normalizes whitespace to reduce rendering abuse vectors.
- */
-export function normalizeSubmitButtonLabel(candidate: unknown, fallback: string): string {
-  if (typeof candidate !== "string") {
-    return fallback;
-  }
-
-  const withoutControlCharacters = candidate.replace(CONTROL_CHARACTER_REGEX, " ");
-  const normalized = withoutControlCharacters.replace(/\s+/g, " ").trim();
-
-  if (!normalized) {
-    return fallback;
-  }
-
-  if (normalized.length <= MAX_LABEL_LENGTH) {
-    return normalized;
-  }
-
-  return `${normalized.slice(0, MAX_LABEL_LENGTH - 3)}...`;
-}
-
-/**
- * @title Label Resolver
- * @notice Returns a safe, non-empty label for the current state.
-/**
- * @title Safe Label Resolver
- * @notice Provides a bounded, non-empty label to avoid empty UI text states.
- * @dev React escapes text content by default; this function only normalizes.
- */
-export function resolveSubmitButtonLabel(
-  state: SubmitButtonState,
-  labels?: SubmitButtonLabels,
-): string {
-  return normalizeSubmitButtonLabel(labels?.[state], DEFAULT_LABELS[state]);
-}
-
-/**
- * @title State Transition Validator
- * @notice Validates deterministic transitions between known button states.
- */
-export function isValidSubmitButtonStateTransition(
-  previousState: SubmitButtonState,
-  nextState: SubmitButtonState,
-): boolean {
-  if (previousState === nextState) {
-    return true;
-  }
-
-  return ALLOWED_STATE_TRANSITIONS[previousState].includes(nextState);
-}
-
-/**
- * @title Safe State Resolver
- * @notice Resolves final state and blocks invalid transitions when strict mode is enabled.
- */
-export function resolveSafeSubmitButtonState(
-  state: SubmitButtonState,
-  previousState?: SubmitButtonState,
-  strictTransitions = true,
-): SubmitButtonState {
-  if (!strictTransitions || !previousState) {
-    return state;
-  }
-
-  return isValidSubmitButtonStateTransition(previousState, state) ? state : previousState;
-}
-
-/**
- * @title Interaction Block Guard
- * @notice Disables interaction while submitting, disabled, or during local in-flight execution.
- */
-export function isSubmitButtonInteractionBlocked(
-  state: SubmitButtonState,
-  disabled = false,
-  isLocallySubmitting = false,
-): boolean {
-  return Boolean(disabled) || state === "disabled" || state === "submitting" || isLocallySubmitting;
-}
-
-/**
- * @title Busy State Guard
- * @notice Reflects busy accessibility semantics for submission and in-flight local execution.
- */
-export function isSubmitButtonBusy(
-  state: SubmitButtonState,
-  isLocallySubmitting = false,
-): boolean {
-  return state === "submitting" || isLocallySubmitting;
-  const candidate = labels?.[state];
-
-  if (typeof candidate !== "string") {
-    return DEFAULT_LABELS[state];
-  }
-
-  const normalized = candidate.trim();
-  if (!normalized) {
-    return DEFAULT_LABELS[state];
-  }
-
-  return normalized.length > 80 ? `${normalized.slice(0, 77)}...` : normalized;
-}
-
-/**
- * @title Disabled Guard
- * @notice Computes final disabled state from explicit disabled flag and workflow state.
- */
-export function isSubmitButtonDisabled(state: SubmitButtonState, disabled?: boolean): boolean {
-  return Boolean(disabled) || state === "disabled" || state === "submitting";
-}
-
-/**
- * @title Aria Busy Guard
- * @notice Announces loading semantics only during active submission.
- */
-export function isSubmitButtonBusy(state: SubmitButtonState): boolean {
-  return state === "submitting";
-}
 
 const BASE_STYLE: React.CSSProperties = {
   minHeight: "44px",
@@ -202,34 +95,119 @@ const BASE_STYLE: React.CSSProperties = {
   backgroundColor: "#4f46e5",
 };
 
-const STATE_STYLE_MAP: Record<SubmitButtonState, React.CSSProperties> = {
+/**
+ * @notice Per-state style overrides.
+ * @security All values are hardcoded constants — no dynamic CSS injection from user input.
+ */
+const STATE_STYLES: Record<SubmitButtonState, React.CSSProperties> = {
   idle: { backgroundColor: "#4f46e5" },
   submitting: { backgroundColor: "#6366f1" },
   success: { backgroundColor: "#16a34a", borderColor: "#15803d" },
   error: { backgroundColor: "#dc2626", borderColor: "#b91c1c" },
-  disabled: {
-    backgroundColor: "#9ca3af",
-    borderColor: "#9ca3af",
-    cursor: "not-allowed",
-    opacity: 0.9,
-  },
   disabled: { backgroundColor: "#9ca3af", borderColor: "#9ca3af", cursor: "not-allowed", opacity: 0.9 },
 };
 
+// ── Pure helpers (exported for unit testing) ──────────────────────────────────
+
 /**
- * @title React Submit Button
- * @notice Reusable submit button with secure labels and transition-aware state handling.
- * @dev `onClick` is blocked while in-flight to reduce duplicate submissions.
+ * @title normalizeSubmitButtonLabel
+ * @notice Sanitizes a candidate label: rejects non-strings, strips control characters,
+ *         normalizes whitespace, and truncates to MAX_LABEL_LENGTH.
+ * @param candidate  Untrusted input (may be any type).
+ * @param fallback   Returned when candidate is unusable.
+ * @security Prevents blank CTA states and layout-abuse via oversized labels.
+ */
+export function normalizeSubmitButtonLabel(candidate: unknown, fallback: string): string {
+  if (typeof candidate !== "string") return fallback;
+  const cleaned = candidate.replace(CONTROL_CHAR_RE, " ").replace(/\s+/g, " ").trim();
+  if (!cleaned) return fallback;
+  if (cleaned.length <= MAX_LABEL_LENGTH) return cleaned;
+  return `${cleaned.slice(0, MAX_LABEL_LENGTH - 3)}...`;
+}
+
+/**
+ * @title resolveSubmitButtonLabel
+ * @notice Returns a safe, non-empty label for the given state.
+ * @param state   Current button state.
+ * @param labels  Optional overrides.
+ */
+export function resolveSubmitButtonLabel(
+  state: SubmitButtonState,
+  labels?: SubmitButtonLabels,
+): string {
+  return normalizeSubmitButtonLabel(labels?.[state], DEFAULT_LABELS[state]);
+}
+
+/**
+ * @title isValidSubmitButtonStateTransition
+ * @notice Returns true when moving from `from` to `to` is an allowed transition.
+ * @dev Same-state updates are always allowed (idempotent).
+ */
+export function isValidSubmitButtonStateTransition(
+  from: SubmitButtonState,
+  to: SubmitButtonState,
+): boolean {
+  return from === to || ALLOWED_TRANSITIONS[from].includes(to);
+}
+
+/**
+ * @title resolveSafeSubmitButtonState
+ * @notice In strict mode, falls back to `previousState` when the transition is invalid.
+ * @param state            Requested next state.
+ * @param previousState    Last known valid state.
+ * @param strictTransitions  Enables transition enforcement. Default: true.
+ */
+export function resolveSafeSubmitButtonState(
+  state: SubmitButtonState,
+  previousState?: SubmitButtonState,
+  strictTransitions = true,
+): SubmitButtonState {
+  if (!strictTransitions || !previousState) return state;
+  return isValidSubmitButtonStateTransition(previousState, state) ? state : previousState;
+}
+
+/**
+ * @title isSubmitButtonInteractionBlocked
+ * @notice Returns true when the button must not respond to clicks.
+ * @param state              Resolved button state.
+ * @param disabled           External disabled flag.
+ * @param isLocallySubmitting  True while an async onClick is in-flight.
+ * @security Prevents duplicate blockchain transactions on rapid clicks.
+ */
+export function isSubmitButtonInteractionBlocked(
+  state: SubmitButtonState,
+  disabled = false,
+  isLocallySubmitting = false,
+): boolean {
+  return Boolean(disabled) || state === "disabled" || state === "submitting" || isLocallySubmitting;
+}
+
+/**
+ * @title isSubmitButtonBusy
+ * @notice Returns true when aria-busy should be set (active submission in progress).
+ * @param state              Resolved button state.
+ * @param isLocallySubmitting  True while an async onClick is in-flight.
+ */
+export function isSubmitButtonBusy(
+  state: SubmitButtonState,
+  isLocallySubmitting = false,
+): boolean {
+  return state === "submitting" || isLocallySubmitting;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+/**
+ * @title ReactSubmitButton
+ * @notice Reusable submit button with strict state machine, safe labels,
+ *         double-submit prevention, and ARIA accessibility.
+ * @dev onClick is wrapped in a local in-flight guard so async handlers cannot
+ *      trigger a second submission before the first resolves.
  */
 const ReactSubmitButton = ({
   state,
   previousState,
   strictTransitions = true,
- * @notice Reusable submit button with typed state machine for scalable workflows.
- * @dev Avoids exposing raw HTML injection paths and enforces accessible semantics.
- */
-const ReactSubmitButton = ({
-  state,
   labels,
   onClick,
   className,
@@ -239,54 +217,35 @@ const ReactSubmitButton = ({
 }: ReactSubmitButtonProps) => {
   const [isLocallySubmitting, setIsLocallySubmitting] = useState(false);
 
-  const resolvedState = useMemo(
-    () => resolveSafeSubmitButtonState(state, previousState, strictTransitions),
-    [state, previousState, strictTransitions],
-  );
-
+  const resolvedState = resolveSafeSubmitButtonState(state, previousState, strictTransitions);
   const label = resolveSubmitButtonLabel(resolvedState, labels);
-  const computedDisabled = isSubmitButtonInteractionBlocked(
-    resolvedState,
-    disabled,
-    isLocallySubmitting,
-  );
+  const blocked = isSubmitButtonInteractionBlocked(resolvedState, disabled, isLocallySubmitting);
   const ariaBusy = isSubmitButtonBusy(resolvedState, isLocallySubmitting);
 
   const handleClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
-    if (computedDisabled || !onClick) {
-      return;
-    }
-
+    if (blocked || !onClick) return;
     setIsLocallySubmitting(true);
     try {
       await Promise.resolve(onClick(event));
+    } catch {
+      // Errors are the caller's responsibility; we only reset local state.
     } finally {
       setIsLocallySubmitting(false);
     }
   };
-  const label = resolveSubmitButtonLabel(state, labels);
-  const computedDisabled = isSubmitButtonDisabled(state, disabled);
-  const ariaBusy = isSubmitButtonBusy(state);
 
   return (
     <button
       id={id}
       type={type}
       className={className}
-      disabled={computedDisabled}
+      disabled={blocked}
       aria-busy={ariaBusy}
       aria-live="polite"
       aria-label={label}
-      onClick={computedDisabled ? undefined : handleClick}
-      style={{
-        ...BASE_STYLE,
-        ...STATE_STYLE_MAP[resolvedState],
-      onClick={computedDisabled ? undefined : onClick}
-      style={{
-        ...BASE_STYLE,
-        ...STATE_STYLE_MAP[state],
-        ...(computedDisabled ? { cursor: "not-allowed", opacity: 0.7 } : {}),
-      }}
+      data-state={resolvedState}
+      onClick={blocked ? undefined : handleClick}
+      style={{ ...BASE_STYLE, ...STATE_STYLES[resolvedState] }}
     >
       {label}
     </button>


### PR DESCRIPTION
feat: create documentation for React submit button component states for dependencies

## Summary

Replaces the outdated react_submit_button.md with a focused dependencies document and carries forward the clean component implementation and test suite 
from the optimization branch.

## Changes

### react_submit_button.md — rewritten as a dependencies reference

Covers:

- **Runtime dependencies** — react ^19 (peer only); zero third-party production packages
- **Dev/test dependencies** — full table with version ranges and roles
- **Peer requirement matrix** — minimum React version (17), minimum TypeScript version (4.7), and what APIs are actually used
- **Explicit exclusions table** — documents what was deliberately NOT added (classnames, styled-components, framer-motion, react-hook-form, zustand, 
lodash, etc.) and why
- **Dependency graph** — visual tree of what imports what
- **Version pinning policy** — caret ranges in package.json, exact pins via package-lock.json, npm ci for reproducible installs
- **React upgrade guide** — 17→18 and 18→19 migration notes (no changes required)
- **Security assumptions** — no dangerouslySetInnerHTML, no dynamic import(), no network calls, no CSS-in-JS runtime
- **NatSpec-style reference** and latest test output

### react_submit_button.tsx / react_submit_button.test.tsx

Carried forward from feature/refactor-react-submit-button-component-states-for-optimization — clean single implementation replacing the corrupted dual-
implementation on main.

## Test output

Tests:    51 passed, 51 total
Coverage: 97.67% statements | 96.87% branches | 100% functions | 100% lines


## Security notes

- Zero third-party runtime dependencies — no transitive supply-chain risk
- All button styles are hardcoded constants; no CSS-in-JS runtime that could be exploited via style injection
- No dangerouslySetInnerHTML anywhere in the component
- close #254