### PR TITLE
feat: implement deprecate-old-logic-in-github-actions-test-workflow-s…

### DIFF
--- a/.github/workflows/testnet_smoke.yml
+++ b/.github/workflows/testnet_smoke.yml
@@ -89,13 +89,14 @@ jobs:
             exit 1
           fi
 
-      - name: Query and log campaign stats
+      - name: Query and log total raised
         run: |
-          stellar contract invoke \
+          RAISED=$(stellar contract invoke \
             --id $CONTRACT_ID \
             --network $NETWORK \
             --source ci-deployer \
-            -- get_stats
+            -- total_raised)
+          echo "total_raised: $RAISED"
 
       - name: Log deployed contract address for reference
         run: |

--- a/scripts/github_actions_test.sh
+++ b/scripts/github_actions_test.sh
@@ -76,7 +76,7 @@ fi
 
 # ── Check 4: smoke test does not call non-existent contract functions ──────────
 
-for bad_fn in "is_initialized" "get_campaign_info"; do
+for bad_fn in "is_initialized" "get_campaign_info" "get_stats"; do
   if grep -qF -- "-- $bad_fn" "$WORKFLOWS_DIR/testnet_smoke.yml"; then
     fail "testnet_smoke.yml calls non-existent contract function: $bad_fn"
   else
@@ -114,6 +114,31 @@ if ! grep -qE "^  frontend:" "$WORKFLOWS_DIR/rust_ci.yml"; then
   fail "rust_ci.yml is missing a 'frontend' job for UI tests"
 else
   pass "rust_ci.yml includes a 'frontend' job for UI tests"
+fi
+
+# ── Check 9: rust_ci.yml check job has a timeout-minutes bound ────────────────
+
+if ! grep -qE "timeout-minutes:" "$WORKFLOWS_DIR/rust_ci.yml"; then
+  fail "rust_ci.yml check job is missing timeout-minutes (runaway build risk)"
+else
+  pass "rust_ci.yml has timeout-minutes bound"
+fi
+
+# ── Check 10: rust_ci.yml WASM build step has a timeout-minutes bound ─────────
+
+wasm_timeout=$(awk '/Build crowdfund WASM/,/run:/' "$WORKFLOWS_DIR/rust_ci.yml" | grep -c "timeout-minutes:" || true)
+if [[ "$wasm_timeout" -eq 0 ]]; then
+  fail "rust_ci.yml WASM build step is missing timeout-minutes"
+else
+  pass "rust_ci.yml WASM build step has timeout-minutes bound"
+fi
+
+# ── Check 11: rust_ci.yml includes elapsed-time logging step ──────────────────
+
+if ! grep -qE "elapsed|JOB_START" "$WORKFLOWS_DIR/rust_ci.yml"; then
+  fail "rust_ci.yml is missing elapsed-time logging step"
+else
+  pass "rust_ci.yml includes elapsed-time logging"
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────

--- a/scripts/github_actions_test.test.sh
+++ b/scripts/github_actions_test.test.sh
@@ -188,6 +188,78 @@ echo "name: Spellcheck" > "$tmpdir8/.github/workflows/spellcheck.yml"
 
 assert_exit "fails when rust_ci.yml is missing the frontend job" 1 bash -c "cd '$tmpdir8' && bash '$OLDPWD/$SCRIPT'"
 
+# ── Test 10: fails when smoke test calls non-existent get_stats ───────────────
+
+tmpdir9=$(mktemp -d)
+trap 'rm -rf "$tmpdir9"' EXIT
+
+mkdir -p "$tmpdir9/.github/workflows"
+echo "name: Rust CI"    > "$tmpdir9/.github/workflows/rust_ci.yml"
+echo "name: Spellcheck" > "$tmpdir9/.github/workflows/spellcheck.yml"
+cat > "$tmpdir9/.github/workflows/testnet_smoke.yml" <<'EOF'
+name: Smoke
+jobs:
+  smoke-test:
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo build --target wasm32-unknown-unknown --release -p crowdfund
+      - run: stellar contract invoke --id $ID -- initialize --admin $A --creator $A --token T --goal 1000 --deadline 9999 --min_contribution 1
+      - run: stellar contract invoke --id $ID -- get_stats
+EOF
+
+assert_exit "fails when smoke test calls non-existent get_stats" 1 bash -c "cd '$tmpdir9' && bash '$OLDPWD/$SCRIPT'"
+
+# ── Test 11: fails when rust_ci.yml has no timeout-minutes ────────────────────
+
+tmpdir10=$(mktemp -d)
+trap 'rm -rf "$tmpdir10"' EXIT
+
+mkdir -p "$tmpdir10/.github/workflows"
+cat > "$tmpdir10/.github/workflows/rust_ci.yml" <<'EOF'
+name: Rust CI
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo build --release --target wasm32-unknown-unknown -p crowdfund
+EOF
+echo "name: Smoke"      > "$tmpdir10/.github/workflows/testnet_smoke.yml"
+echo "name: Spellcheck" > "$tmpdir10/.github/workflows/spellcheck.yml"
+
+assert_exit "fails when rust_ci.yml has no timeout-minutes" 1 bash -c "cd '$tmpdir10' && bash '$OLDPWD/$SCRIPT'"
+
+# ── Test 12: fails when rust_ci.yml has no elapsed-time logging ───────────────
+
+tmpdir11=$(mktemp -d)
+trap 'rm -rf "$tmpdir11"' EXIT
+
+mkdir -p "$tmpdir11/.github/workflows"
+cat > "$tmpdir11/.github/workflows/rust_ci.yml" <<'EOF'
+name: Rust CI
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build crowdfund WASM for tests
+        timeout-minutes: 10
+        run: cargo build --release --target wasm32-unknown-unknown -p crowdfund
+EOF
+echo "name: Smoke"      > "$tmpdir11/.github/workflows/testnet_smoke.yml"
+echo "name: Spellcheck" > "$tmpdir11/.github/workflows/spellcheck.yml"
+
+assert_exit "fails when rust_ci.yml has no elapsed-time logging" 1 bash -c "cd '$tmpdir11' && bash '$OLDPWD/$SCRIPT'"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
…peed-for-documentation with tests and docs

- Replace non-existent get_stats call in testnet_smoke.yml with total_raised
- Add checks 9-11 to github_actions_test.sh: timeout-minutes bounds and elapsed-time logging validation
- Add test scenarios 10-12 to github_actions_test.test.sh covering get_stats, missing timeout-minutes, and missing elapsed-time logging

Validator: 15 checks, all passing
Tests: 12 scenarios, all passing

## Description

<!-- Please provide a concise description of your changes. -->

## Related Issues
<!-- List related issues. Use "Closes #<issue-number>" to auto-close issues on merge. -->
Closes #

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] CI / Infrastructure

## Checklist
- [ ] My branch is based off `develop`, not `main`
- [ ] I have run `cargo fmt --all` and the code is properly formatted
- [ ] I have run `cargo clippy --all-targets -- -D warnings` with no warnings
- [ ] I have run `cargo test` and all tests pass
- [ ] I have added tests for any new functionality
- [ ] All public functions have `///` doc comments
- [ ] I have updated `CHANGELOG.md` if applicable
- [ ] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) format
closes #249