### PR TITLE
feat: fix typo in frontend global error boundaries for security

### DIFF
--- a/frontend/components/frontend_global_error.md
+++ b/frontend/components/frontend_global_error.md
@@ -253,6 +253,7 @@ try {
 - **User-Friendly Messages**: Technical errors translated to user-understandable language
 - **Actionable Guidance**: Clear instructions for resolving common issues
 - **Security Boundaries**: Prevents sensitive contract data exposure
+- **Dismiss Action**: The `handleDismiss` method resets error state and re-renders children. Use with caution — it does not resolve the underlying error and should only be offered when the error is known to be transient.
 
 ---
 

--- a/frontend/utils/frontend_global_error.test.tsx
+++ b/frontend/utils/frontend_global_error.test.tsx
@@ -708,4 +708,44 @@ describe('Security Considerations', () => {
     // Error message should be displayed
     expect(screen.getByText(/Token:/)).toBeInTheDocument();
   });
+
+  it('dismiss button is labelled correctly (aria-label)', () => {
+    render(
+      <GlobalErrorBoundary>
+        <ThrowError />
+      </GlobalErrorBoundary>
+    );
+    const dismissBtn = screen.getByRole('button', { name: /dismiss error/i });
+    expect(dismissBtn).toBeTruthy();
+    expect(dismissBtn.getAttribute('aria-label')).toBe(
+      'Dismiss error and try to continue',
+    );
+  });
+
+  it('clicking Dismiss resets error state and re-renders children', () => {
+    let shouldThrow = true;
+    const Recoverable = () => {
+      if (shouldThrow) throw new Error('dismissable error');
+      return <div>Dismissed OK</div>;
+    };
+    render(
+      <GlobalErrorBoundary>
+        <Recoverable />
+      </GlobalErrorBoundary>
+    );
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole('button', { name: /dismiss error/i }));
+    expect(screen.getByText('Dismissed OK')).toBeTruthy();
+  });
+
+  it('dismiss action does not expose stack trace to the DOM', () => {
+    render(
+      <GlobalErrorBoundary config={{ showErrorDetails: false }}>
+        <ThrowError />
+      </GlobalErrorBoundary>
+    );
+    // pre element (stack trace) must not be present
+    expect(document.querySelector('pre')).toBeNull();
+  });
 });

--- a/frontend/utils/frontend_global_error.tsx
+++ b/frontend/utils/frontend_global_error.tsx
@@ -375,7 +375,7 @@ export class GlobalErrorBoundary extends Component<
 
   /**
    * @notice Handles dismiss action
-   * @dev Dismesses the error and shows children anyway (dangerous)
+   * @dev Dismisses the error and shows children anyway (dangerous)
    */
   private handleDismiss = (): void => {
     this.setState({


### PR DESCRIPTION
## Summary

Fixes a typo in the GlobalErrorBoundary dismiss action JSDoc comment and adds security-focused tests for the dismiss behaviour.

## Changes

### frontend/utils/frontend_global_error.tsx
- Fixed typo: "Dismesses" → "Dismisses" in handleDismiss JSDoc (@dev comment, line 379)

### frontend/utils/frontend_global_error.test.tsx
- Added 3 new security tests in the Security Considerations suite:
  - dismiss button is labelled correctly (aria-label)
  - clicking Dismiss resets error state and re-renders children
  - dismiss action does not expose stack trace to the DOM

### frontend/components/frontend_global_error.md
- Added security note for the Dismiss action: clarifies it resets error state without resolving the underlying error and should only be offered for transient errors

## Security Notes
- The dismiss action (handleDismiss) is documented as dangerous — it re-renders children without resolving the underlying error
- New tests verify the dismiss button has the correct aria-label for accessibility and screen readers
- New test confirms no stack trace (pre element) is exposed to the DOM when showErrorDetails is false

## Test Results
All 3 new security tests pass.

closes #425 