### PR TITLE
Add campaign creation form

### DIFF
--- a/apps/frontend/components/forms/CampaignCreateForm.test.tsx
+++ b/apps/frontend/components/forms/CampaignCreateForm.test.tsx
@@ -1,0 +1,137 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import CampaignCreateForm from "./CampaignCreateForm";
+import { CreateCampaign } from "../../utils/sorobanCampaignFactory";
+
+function fillValidForm() {
+  fireEvent.change(screen.getByLabelText("Campaign title"), {
+    target: { value: "Community Solar" },
+  });
+  fireEvent.change(screen.getByLabelText("Campaign description"), {
+    target: { value: "Funding a community solar installation." },
+  });
+  fireEvent.change(screen.getByLabelText("Goal amount"), {
+    target: { value: "1000" },
+  });
+  fireEvent.change(screen.getByLabelText("Deadline"), {
+    target: { value: "2099-06-19" },
+  });
+  fireEvent.change(screen.getByLabelText("Token contract address"), {
+    target: {
+      value: "CBIELUBUIXM6GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    },
+  });
+  fireEvent.change(screen.getByLabelText("Minimum contribution"), {
+    target: { value: "25" },
+  });
+  fireEvent.change(screen.getByLabelText("Bonus goal"), {
+    target: { value: "1500" },
+  });
+}
+
+describe("CampaignCreateForm", () => {
+  it("renders all required campaign fields with accessible labels", () => {
+    render(<CampaignCreateForm creatorPublicKey="GCREATOR" />);
+
+    expect(screen.getByLabelText("Campaign title")).toBeInTheDocument();
+    expect(screen.getByLabelText("Campaign description")).toBeInTheDocument();
+    expect(screen.getByLabelText("Goal amount")).toBeInTheDocument();
+    expect(screen.getByLabelText("Deadline")).toBeInTheDocument();
+    expect(screen.getByLabelText("Token contract address")).toBeInTheDocument();
+    expect(screen.getByLabelText("Minimum contribution")).toBeInTheDocument();
+    expect(screen.getByLabelText("Bonus goal")).toBeInTheDocument();
+  });
+
+  it("shows validation errors before submission when fields are blurred", () => {
+    render(<CampaignCreateForm creatorPublicKey="GCREATOR" />);
+
+    fireEvent.change(screen.getByLabelText("Goal amount"), {
+      target: { value: "0" },
+    });
+    fireEvent.blur(screen.getByLabelText("Goal amount"));
+
+    fireEvent.change(screen.getByLabelText("Deadline"), {
+      target: { value: "2020-01-01" },
+    });
+    fireEvent.blur(screen.getByLabelText("Deadline"));
+
+    expect(
+      screen.getByText("Goal must be greater than 0."),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Deadline must be in the future."),
+    ).toBeInTheDocument();
+  });
+
+  it("does not submit when validation errors are present", async () => {
+    const createCampaign = vi.fn<CreateCampaign>();
+
+    render(
+      <CampaignCreateForm
+        creatorPublicKey="GCREATOR"
+        createCampaign={createCampaign}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Create campaign" }));
+
+    expect(await screen.findAllByText("This field is required.")).toHaveLength(
+      6,
+    );
+    expect(createCampaign).not.toHaveBeenCalled();
+  });
+
+  it("submits a valid form through the factory call and shows success", async () => {
+    const createCampaign = vi
+      .fn<CreateCampaign>()
+      .mockResolvedValue({ campaignAddress: "CCAMPAIGN" });
+
+    render(
+      <CampaignCreateForm
+        creatorPublicKey="GCREATOR"
+        createCampaign={createCampaign}
+      />,
+    );
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Create campaign" }));
+
+    await waitFor(() => {
+      expect(createCampaign).toHaveBeenCalledTimes(1);
+    });
+
+    expect(createCampaign).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creatorPublicKey: "GCREATOR",
+        title: "Community Solar",
+        goalAmount: 1000,
+        tokenAddress:
+          "CBIELUBUIXM6GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        minimumContribution: 25,
+        bonusGoal: 1500,
+      }),
+    );
+    expect(
+      await screen.findByText("Campaign created at CCAMPAIGN."),
+    ).toBeTruthy();
+  });
+
+  it("shows an error when the factory call fails", async () => {
+    const createCampaign = vi
+      .fn<CreateCampaign>()
+      .mockRejectedValue(new Error("Wallet rejected the transaction."));
+
+    render(
+      <CampaignCreateForm
+        creatorPublicKey="GCREATOR"
+        createCampaign={createCampaign}
+      />,
+    );
+
+    fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: "Create campaign" }));
+
+    expect(
+      await screen.findByText("Wallet rejected the transaction."),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/components/forms/CampaignCreateForm.tsx
+++ b/apps/frontend/components/forms/CampaignCreateForm.tsx
@@ -1,0 +1,354 @@
+import { ChangeEvent, FormEvent, useMemo, useState } from "react";
+import {
+  CampaignValidationErrors,
+  CampaignValidationField,
+  CampaignValidationValues,
+  dateStringToDeadlineTimestamp,
+  hasCampaignValidationErrors,
+  parseAmount,
+  validateCampaign,
+  validateCampaignField,
+} from "../../utils/campaignValidation";
+import {
+  createCampaign as defaultCreateCampaign,
+  CreateCampaign,
+} from "../../utils/sorobanCampaignFactory";
+import "./Forms.css";
+
+interface CampaignCreateFormProps {
+  creatorPublicKey: string;
+  createCampaign?: CreateCampaign;
+}
+
+type SubmissionState = "idle" | "loading" | "success" | "error";
+
+const initialValues: CampaignValidationValues = {
+  title: "",
+  description: "",
+  goalAmount: "",
+  deadline: "",
+  tokenAddress: "",
+  minimumContribution: "",
+  bonusGoal: "",
+};
+
+const fieldOrder: CampaignValidationField[] = [
+  "title",
+  "description",
+  "goalAmount",
+  "deadline",
+  "tokenAddress",
+  "minimumContribution",
+  "bonusGoal",
+];
+
+function buildDescribedBy(
+  field: CampaignValidationField,
+  error?: string,
+  hintId?: string,
+) {
+  const ids = [hintId, error ? `${field}-error` : undefined].filter(Boolean);
+  return ids.length > 0 ? ids.join(" ") : undefined;
+}
+
+export default function CampaignCreateForm({
+  creatorPublicKey,
+  createCampaign = defaultCreateCampaign,
+}: CampaignCreateFormProps) {
+  const [values, setValues] = useState<CampaignValidationValues>(initialValues);
+  const [touched, setTouched] = useState<
+    Partial<Record<CampaignValidationField, boolean>>
+  >({});
+  const [errors, setErrors] = useState<CampaignValidationErrors>({});
+  const [submissionState, setSubmissionState] =
+    useState<SubmissionState>("idle");
+  const [statusMessage, setStatusMessage] = useState("");
+
+  const isSubmitting = submissionState === "loading";
+
+  const statusClassName = useMemo(() => {
+    if (submissionState === "idle") {
+      return "";
+    }
+
+    return `form__status form__status--${submissionState === "loading" ? "loading" : submissionState}`;
+  }, [submissionState]);
+
+  const updateField =
+    (field: CampaignValidationField) =>
+    (
+      event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>,
+    ) => {
+      const nextValues = { ...values, [field]: event.target.value };
+      setValues(nextValues);
+
+      if (touched[field]) {
+        setErrors((currentErrors) => ({
+          ...currentErrors,
+          [field]: validateCampaignField(field, nextValues),
+        }));
+      }
+
+      if (submissionState !== "idle") {
+        setSubmissionState("idle");
+        setStatusMessage("");
+      }
+    };
+
+  const markTouched = (field: CampaignValidationField) => () => {
+    setTouched((currentTouched) => ({ ...currentTouched, [field]: true }));
+    setErrors((currentErrors) => ({
+      ...currentErrors,
+      [field]: validateCampaignField(field, values),
+    }));
+  };
+
+  const renderError = (field: CampaignValidationField) =>
+    errors[field] ? (
+      <p className="form__error" id={`${field}-error`} role="alert">
+        {errors[field]}
+      </p>
+    ) : null;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const nextErrors = validateCampaign(values);
+    setTouched(
+      fieldOrder.reduce(
+        (nextTouched, field) => ({ ...nextTouched, [field]: true }),
+        {} as Record<CampaignValidationField, boolean>,
+      ),
+    );
+    setErrors(nextErrors);
+
+    if (hasCampaignValidationErrors(nextErrors)) {
+      setSubmissionState("error");
+      setStatusMessage(
+        "Fix the highlighted fields before creating a campaign.",
+      );
+      return;
+    }
+
+    const goalAmount = parseAmount(values.goalAmount);
+    const deadline = dateStringToDeadlineTimestamp(values.deadline);
+    const minimumContribution = parseAmount(values.minimumContribution);
+    const bonusGoal = parseAmount(values.bonusGoal);
+
+    if (
+      goalAmount === null ||
+      deadline === null ||
+      minimumContribution === null
+    ) {
+      return;
+    }
+
+    setSubmissionState("loading");
+    setStatusMessage("Submitting campaign transaction...");
+
+    try {
+      const result = await createCampaign({
+        creatorPublicKey,
+        title: values.title.trim(),
+        description: values.description.trim(),
+        goalAmount,
+        deadline,
+        tokenAddress: values.tokenAddress.trim(),
+        minimumContribution,
+        ...(bonusGoal === null ? {} : { bonusGoal }),
+      });
+
+      setSubmissionState("success");
+      setStatusMessage(`Campaign created at ${result.campaignAddress}.`);
+    } catch (error) {
+      setSubmissionState("error");
+      setStatusMessage(
+        error instanceof Error
+          ? error.message
+          : "Campaign creation failed. Try again.",
+      );
+    }
+  };
+
+  return (
+    <form className="form" noValidate onSubmit={handleSubmit}>
+      <div className="form__group">
+        <label className="form__label form__label--required" htmlFor="title">
+          Campaign title
+        </label>
+        <input
+          aria-describedby={buildDescribedBy("title", errors.title)}
+          aria-invalid={Boolean(errors.title)}
+          className={`form__input${errors.title ? " form__input--error" : ""}`}
+          disabled={isSubmitting}
+          id="title"
+          name="title"
+          onBlur={markTouched("title")}
+          onChange={updateField("title")}
+          type="text"
+          value={values.title}
+        />
+        {renderError("title")}
+      </div>
+
+      <div className="form__group">
+        <label
+          className="form__label form__label--required"
+          htmlFor="description"
+        >
+          Campaign description
+        </label>
+        <textarea
+          aria-describedby={buildDescribedBy("description", errors.description)}
+          aria-invalid={Boolean(errors.description)}
+          className={`form__textarea${errors.description ? " form__textarea--error" : ""}`}
+          disabled={isSubmitting}
+          id="description"
+          name="description"
+          onBlur={markTouched("description")}
+          onChange={updateField("description")}
+          value={values.description}
+        />
+        {renderError("description")}
+      </div>
+
+      <div className="form__group">
+        <label
+          className="form__label form__label--required"
+          htmlFor="goalAmount"
+        >
+          Goal amount
+        </label>
+        <input
+          aria-describedby={buildDescribedBy("goalAmount", errors.goalAmount)}
+          aria-invalid={Boolean(errors.goalAmount)}
+          className={`form__input${errors.goalAmount ? " form__input--error" : ""}`}
+          disabled={isSubmitting}
+          id="goalAmount"
+          inputMode="decimal"
+          min="0"
+          name="goalAmount"
+          onBlur={markTouched("goalAmount")}
+          onChange={updateField("goalAmount")}
+          step="any"
+          type="number"
+          value={values.goalAmount}
+        />
+        {renderError("goalAmount")}
+      </div>
+
+      <div className="form__group">
+        <label className="form__label form__label--required" htmlFor="deadline">
+          Deadline
+        </label>
+        <input
+          aria-describedby={buildDescribedBy("deadline", errors.deadline)}
+          aria-invalid={Boolean(errors.deadline)}
+          className={`form__input${errors.deadline ? " form__input--error" : ""}`}
+          disabled={isSubmitting}
+          id="deadline"
+          name="deadline"
+          onBlur={markTouched("deadline")}
+          onChange={updateField("deadline")}
+          type="date"
+          value={values.deadline}
+        />
+        {renderError("deadline")}
+      </div>
+
+      <div className="form__group">
+        <label
+          className="form__label form__label--required"
+          htmlFor="tokenAddress"
+        >
+          Token contract address
+        </label>
+        <input
+          aria-describedby={buildDescribedBy(
+            "tokenAddress",
+            errors.tokenAddress,
+            "tokenAddress-hint",
+          )}
+          aria-invalid={Boolean(errors.tokenAddress)}
+          className={`form__input${errors.tokenAddress ? " form__input--error" : ""}`}
+          disabled={isSubmitting}
+          id="tokenAddress"
+          name="tokenAddress"
+          onBlur={markTouched("tokenAddress")}
+          onChange={updateField("tokenAddress")}
+          type="text"
+          value={values.tokenAddress}
+        />
+        <p className="form__hint" id="tokenAddress-hint">
+          Stellar contract address beginning with C.
+        </p>
+        {renderError("tokenAddress")}
+      </div>
+
+      <div className="form__group">
+        <label
+          className="form__label form__label--required"
+          htmlFor="minimumContribution"
+        >
+          Minimum contribution
+        </label>
+        <input
+          aria-describedby={buildDescribedBy(
+            "minimumContribution",
+            errors.minimumContribution,
+          )}
+          aria-invalid={Boolean(errors.minimumContribution)}
+          className={`form__input${errors.minimumContribution ? " form__input--error" : ""}`}
+          disabled={isSubmitting}
+          id="minimumContribution"
+          inputMode="decimal"
+          min="0"
+          name="minimumContribution"
+          onBlur={markTouched("minimumContribution")}
+          onChange={updateField("minimumContribution")}
+          step="any"
+          type="number"
+          value={values.minimumContribution}
+        />
+        {renderError("minimumContribution")}
+      </div>
+
+      <div className="form__group">
+        <label className="form__label" htmlFor="bonusGoal">
+          Bonus goal
+        </label>
+        <input
+          aria-describedby={buildDescribedBy("bonusGoal", errors.bonusGoal)}
+          aria-invalid={Boolean(errors.bonusGoal)}
+          className={`form__input${errors.bonusGoal ? " form__input--error" : ""}`}
+          disabled={isSubmitting}
+          id="bonusGoal"
+          inputMode="decimal"
+          min="0"
+          name="bonusGoal"
+          onBlur={markTouched("bonusGoal")}
+          onChange={updateField("bonusGoal")}
+          step="any"
+          type="number"
+          value={values.bonusGoal}
+        />
+        {renderError("bonusGoal")}
+      </div>
+
+      {statusMessage ? (
+        <div className={statusClassName} role="status">
+          {statusMessage}
+        </div>
+      ) : null}
+
+      <button
+        aria-busy={isSubmitting}
+        className="btn btn--primary btn--full"
+        disabled={isSubmitting}
+        type="submit"
+      >
+        {isSubmitting ? "Creating campaign..." : "Create campaign"}
+      </button>
+    </form>
+  );
+}

--- a/apps/frontend/components/forms/Forms.css
+++ b/apps/frontend/components/forms/Forms.css
@@ -110,6 +110,31 @@
   flex-shrink: 0;
 }
 
+.form__status {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.form__status--loading {
+  color: var(--color-primary-blue);
+  background-color: rgba(0, 102, 255, 0.08);
+  border: 1px solid rgba(0, 102, 255, 0.32);
+}
+
+.form__status--success {
+  color: #0f7a3b;
+  background-color: rgba(18, 183, 106, 0.1);
+  border: 1px solid rgba(18, 183, 106, 0.36);
+}
+
+.form__status--error {
+  color: var(--color-error-red);
+  background-color: rgba(255, 59, 48, 0.08);
+  border: 1px solid rgba(255, 59, 48, 0.32);
+}
+
 /* Checkbox and Radio */
 .form__checkbox,
 .form__radio {

--- a/apps/frontend/utils/campaignValidation.test.ts
+++ b/apps/frontend/utils/campaignValidation.test.ts
@@ -1,0 +1,105 @@
+import {
+  CampaignValidationValues,
+  dateStringToDeadlineTimestamp,
+  hasCampaignValidationErrors,
+  parseAmount,
+  validateCampaign,
+  validateCampaignField,
+} from "./campaignValidation";
+
+const now = new Date("2026-06-18T12:00:00.000Z");
+
+const validValues: CampaignValidationValues = {
+  title: "Community Solar",
+  description: "Funding a community solar installation.",
+  goalAmount: "1000",
+  deadline: "2026-06-19",
+  tokenAddress: "CBIELUBUIXM6GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+  minimumContribution: "25",
+  bonusGoal: "1500",
+};
+
+describe("campaign validation", () => {
+  it("accepts a valid campaign", () => {
+    const errors = validateCampaign(validValues, now);
+    expect(hasCampaignValidationErrors(errors)).toBe(false);
+  });
+
+  it("rejects a zero goal before submission", () => {
+    const error = validateCampaignField(
+      "goalAmount",
+      { ...validValues, goalAmount: "0" },
+      now,
+    );
+
+    expect(error).toBe("Goal must be greater than 0.");
+  });
+
+  it("rejects a deadline in the past before submission", () => {
+    const error = validateCampaignField(
+      "deadline",
+      { ...validValues, deadline: "2026-06-17" },
+      now,
+    );
+
+    expect(error).toBe("Deadline must be in the future.");
+  });
+
+  it("rejects a minimum contribution above the goal", () => {
+    const error = validateCampaignField(
+      "minimumContribution",
+      { ...validValues, minimumContribution: "1001" },
+      now,
+    );
+
+    expect(error).toBe("Minimum contribution cannot exceed the goal.");
+  });
+
+  it("rejects a bonus goal that is not greater than the primary goal", () => {
+    const error = validateCampaignField(
+      "bonusGoal",
+      { ...validValues, bonusGoal: "1000" },
+      now,
+    );
+
+    expect(error).toBe("Bonus goal must be greater than the goal.");
+  });
+
+  it("allows the optional bonus goal to be empty", () => {
+    const errors = validateCampaign({ ...validValues, bonusGoal: "" }, now);
+    expect(errors.bonusGoal).toBeUndefined();
+  });
+
+  it("marks all required fields as invalid when empty", () => {
+    const errors = validateCampaign(
+      {
+        title: "",
+        description: "",
+        goalAmount: "",
+        deadline: "",
+        tokenAddress: "",
+        minimumContribution: "",
+        bonusGoal: "",
+      },
+      now,
+    );
+
+    expect(errors.title).toBe("This field is required.");
+    expect(errors.description).toBe("This field is required.");
+    expect(errors.goalAmount).toBe("This field is required.");
+    expect(errors.deadline).toBe("This field is required.");
+    expect(errors.tokenAddress).toBe("This field is required.");
+    expect(errors.minimumContribution).toBe("This field is required.");
+  });
+
+  it("parses decimal amounts for XLM or token unit input", () => {
+    expect(parseAmount("12.5")).toBe(12.5);
+    expect(parseAmount("abc")).toBeNull();
+  });
+
+  it("encodes a date field as an end-of-day unix timestamp", () => {
+    expect(dateStringToDeadlineTimestamp("2026-06-19")).toBe(
+      Math.floor(new Date(2026, 5, 19, 23, 59, 59, 999).getTime() / 1000),
+    );
+  });
+});

--- a/apps/frontend/utils/campaignValidation.ts
+++ b/apps/frontend/utils/campaignValidation.ts
@@ -1,0 +1,150 @@
+export interface CampaignValidationValues {
+  title: string;
+  description: string;
+  goalAmount: string;
+  deadline: string;
+  tokenAddress: string;
+  minimumContribution: string;
+  bonusGoal: string;
+}
+
+export type CampaignValidationField = keyof CampaignValidationValues;
+
+export type CampaignValidationErrors = Partial<
+  Record<CampaignValidationField, string>
+>;
+
+const REQUIRED_MESSAGE = "This field is required.";
+const CONTRACT_ADDRESS_PATTERN = /^C[A-Z2-7]{10,}$/;
+
+export function parseAmount(value: string): number | null {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    return null;
+  }
+
+  const amount = Number(trimmedValue);
+
+  if (!Number.isFinite(amount)) {
+    return null;
+  }
+
+  return amount;
+}
+
+export function dateStringToDeadlineTimestamp(value: string): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const [year, month, day] = value.split("-").map(Number);
+
+  if (!year || !month || !day) {
+    return null;
+  }
+
+  return Math.floor(
+    new Date(year, month - 1, day, 23, 59, 59, 999).getTime() / 1000,
+  );
+}
+
+export function validateCampaignField(
+  field: CampaignValidationField,
+  values: CampaignValidationValues,
+  now: Date = new Date(),
+): string | undefined {
+  const value = values[field].trim();
+
+  if (field !== "bonusGoal" && !value) {
+    return REQUIRED_MESSAGE;
+  }
+
+  if (field === "bonusGoal" && !value) {
+    return undefined;
+  }
+
+  if (field === "goalAmount") {
+    const goalAmount = parseAmount(value);
+
+    if (goalAmount === null) {
+      return "Goal must be a valid number.";
+    }
+
+    if (goalAmount <= 0) {
+      return "Goal must be greater than 0.";
+    }
+  }
+
+  if (field === "deadline") {
+    const deadlineTimestamp = dateStringToDeadlineTimestamp(value);
+
+    if (deadlineTimestamp === null) {
+      return "Deadline must be a valid date.";
+    }
+
+    if (deadlineTimestamp <= Math.floor(now.getTime() / 1000)) {
+      return "Deadline must be in the future.";
+    }
+  }
+
+  if (field === "tokenAddress" && !CONTRACT_ADDRESS_PATTERN.test(value)) {
+    return "Token contract address must be a valid Stellar contract address.";
+  }
+
+  if (field === "minimumContribution") {
+    const minimumContribution = parseAmount(value);
+    const goalAmount = parseAmount(values.goalAmount);
+
+    if (minimumContribution === null) {
+      return "Minimum contribution must be a valid number.";
+    }
+
+    if (minimumContribution <= 0) {
+      return "Minimum contribution must be greater than 0.";
+    }
+
+    if (goalAmount !== null && minimumContribution > goalAmount) {
+      return "Minimum contribution cannot exceed the goal.";
+    }
+  }
+
+  if (field === "bonusGoal") {
+    const bonusGoal = parseAmount(value);
+    const goalAmount = parseAmount(values.goalAmount);
+
+    if (bonusGoal === null) {
+      return "Bonus goal must be a valid number.";
+    }
+
+    if (goalAmount !== null && bonusGoal <= goalAmount) {
+      return "Bonus goal must be greater than the goal.";
+    }
+  }
+
+  return undefined;
+}
+
+export function validateCampaign(
+  values: CampaignValidationValues,
+  now: Date = new Date(),
+): CampaignValidationErrors {
+  return (Object.keys(values) as CampaignValidationField[]).reduce(
+    (errors, field) => {
+      const error = validateCampaignField(field, values, now);
+
+      if (error) {
+        errors[field] = error;
+      }
+
+      return errors;
+    },
+    {} as CampaignValidationErrors,
+  );
+}
+
+export function hasCampaignValidationErrors(
+  errors: CampaignValidationErrors,
+): boolean {
+  return Object.values(errors).some(Boolean);
+}

--- a/apps/frontend/utils/sorobanCampaignFactory.ts
+++ b/apps/frontend/utils/sorobanCampaignFactory.ts
@@ -1,0 +1,24 @@
+export interface CreateCampaignInput {
+  creatorPublicKey: string;
+  title: string;
+  description: string;
+  goalAmount: number;
+  deadline: number;
+  tokenAddress: string;
+  minimumContribution: number;
+  bonusGoal?: number;
+}
+
+export interface CreateCampaignResult {
+  campaignAddress: string;
+}
+
+export type CreateCampaign = (
+  input: CreateCampaignInput,
+) => Promise<CreateCampaignResult>;
+
+export const createCampaign: CreateCampaign = async () => {
+  throw new Error(
+    "Campaign factory integration is not configured. Wire this adapter to Issue #10's Soroban client.",
+  );
+};


### PR DESCRIPTION
closes #1263 

## Summary
- add a controlled CampaignCreateForm with accessible labels, inline validation, and transaction loading/success/error states
- add pure campaign validation utilities and a Soroban factory adapter interface for future Issue #10 wiring
- add Vitest coverage for validation and mocked submit behavior

## Tests
- pnpm --filter @stellar-raise/frontend typecheck
- pnpm --filter @stellar-raise/frontend test