### PR TITLE
Add factory registry coverage

### DIFF
--- a/apps/contracts/factory/src/batch_contribute.rs
+++ b/apps/contracts/factory/src/batch_contribute.rs
@@ -96,23 +96,17 @@ pub fn batch_contribute(env: &Env, contributor: &Address, entries: Vec<Contribut
         let _: () = env.invoke_contract(
             &entry.campaign,
             &Symbol::new(env, "contribute"),
-            soroban_sdk::vec![env, contributor.clone().into(), entry.amount.into(),],
             soroban_sdk::vec![
                 env,
-                contributor.clone().into(),
-                entry.amount.into(),
+                contributor.clone().into_val(env),
+                entry.amount.into_val(env),
             ],
-            soroban_sdk::vec![env, contributor.clone().into_val(env), entry.amount.into_val(env),],
         );
     }
 
     // Emit a single summary event — cheaper than one event per campaign.
     env.events().publish(
         (Symbol::new(env, "batch"), Symbol::new(env, "contributed")),
-        (
-            Symbol::new(env, "batch"),
-            Symbol::new(env, "contributed"),
-        ),
         (contributor.clone(), len),
     );
 }

--- a/apps/contracts/factory/src/batch_contribute_tests.rs
+++ b/apps/contracts/factory/src/batch_contribute_tests.rs
@@ -99,6 +99,23 @@ fn batch_multiple_campaigns_all_funded() {
 }
 
 #[test]
+fn batch_routes_repeated_entries_to_their_target_campaigns() {
+    let (env, contributor) = setup();
+    let c1 = register_campaign(&env);
+    let c2 = register_campaign(&env);
+
+    let mut entries = Vec::new(&env);
+    entries.push_back(entry(c1.clone(), 250));
+    entries.push_back(entry(c2.clone(), 750));
+    entries.push_back(entry(c1.clone(), 1_250));
+
+    batch_contribute(&env, &contributor, entries);
+
+    assert_eq!(MockCampaignClient::new(&env, &c1).total(), 1_500);
+    assert_eq!(MockCampaignClient::new(&env, &c2).total(), 750);
+}
+
+#[test]
 fn batch_at_max_size_succeeds() {
     let (env, contributor) = setup();
     let mut entries = Vec::new(&env);

--- a/apps/contracts/factory/src/lib.rs
+++ b/apps/contracts/factory/src/lib.rs
@@ -6,6 +6,10 @@ use soroban_sdk::{
 
 #[cfg(test)]
 mod test;
+#[cfg(test)]
+mod batch_contribute;
+#[cfg(test)]
+mod batch_contribute_tests;
 
 #[derive(Clone)]
 #[contracttype]

--- a/apps/contracts/factory/src/test.rs
+++ b/apps/contracts/factory/src/test.rs
@@ -2,7 +2,10 @@
 #![allow(clippy::too_many_arguments)]
 
 use crate::{FactoryContract, FactoryContractClient};
-use soroban_sdk::{testutils::Address as _, token, Address, Env};
+use soroban_sdk::{
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    token, Address, Env, IntoVal,
+};
 
 extern crate std;
 
@@ -24,74 +27,203 @@ fn create_token_contract<'a>(
     (token_address, token_client)
 }
 
-#[test]
-#[ignore = "requires wasm-opt for WASM optimization"]
-fn test_create_single_campaign() {
+fn setup_factory(mock_auths: bool) -> (Env, Address, Address, soroban_sdk::BytesN<32>) {
     let env = Env::default();
-    env.mock_all_auths();
+    if mock_auths {
+        env.mock_all_auths();
+    }
 
     let factory_id = env.register(FactoryContract, ());
-    let factory = FactoryContractClient::new(&env, &factory_id);
 
-    let creator = Address::generate(&env);
     let token_admin = Address::generate(&env);
     let (token_address, _token_client) = create_token_contract(&env, &token_admin);
-
-    // Upload the crowdfund WASM.
     let wasm_hash = env.deployer().upload_contract_wasm(crowdfund_wasm::WASM);
 
+    (env, factory_id, token_address, wasm_hash)
+}
+
+fn create_campaign(
+    factory: &FactoryContractClient<'_>,
+    creator: &Address,
+    token_address: &Address,
+    wasm_hash: &soroban_sdk::BytesN<32>,
+    goal: i128,
+    deadline: u64,
+) -> Address {
+    factory.create_campaign(creator, token_address, &goal, &deadline, wasm_hash)
+}
+
+#[test]
+fn test_create_single_campaign_registers_returned_address() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(true);
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let creator = Address::generate(&env);
     let goal = 1000i128;
     let deadline = 100u64;
 
     let campaign_addr =
-        factory.create_campaign(&creator, &token_address, &goal, &deadline, &wasm_hash);
+        create_campaign(&factory, &creator, &token_address, &wasm_hash, goal, deadline);
 
-    // Verify campaign was added to registry.
+    assert_ne!(campaign_addr, factory_id);
+    assert_ne!(campaign_addr, token_address);
+
     let campaigns = factory.campaigns();
     assert_eq!(campaigns.len(), 1);
     assert_eq!(campaigns.get(0).unwrap(), campaign_addr);
-
-    // Verify count.
     assert_eq!(factory.campaign_count(), 1);
 }
 
 #[test]
-#[ignore = "requires wasm-opt for WASM optimization"]
-fn test_create_multiple_campaigns() {
-    let env = Env::default();
-    env.mock_all_auths();
+fn test_campaign_count_increments_after_each_deployment() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(true);
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    assert_eq!(factory.campaign_count(), 0);
 
-    let factory_id = env.register(FactoryContract, ());
+    let creator1 = Address::generate(&env);
+    create_campaign(&factory, &creator1, &token_address, &wasm_hash, 1000, 100);
+    assert_eq!(factory.campaign_count(), 1);
+
+    let creator2 = Address::generate(&env);
+    create_campaign(&factory, &creator2, &token_address, &wasm_hash, 2000, 200);
+    assert_eq!(factory.campaign_count(), 2);
+
+    let creator3 = Address::generate(&env);
+    create_campaign(&factory, &creator3, &token_address, &wasm_hash, 3000, 300);
+    assert_eq!(factory.campaign_count(), 3);
+}
+
+#[test]
+fn test_multiple_campaigns_are_registered_in_insertion_order() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(true);
     let factory = FactoryContractClient::new(&env, &factory_id);
 
-    let token_admin = Address::generate(&env);
-    let (token_address, _token_client) = create_token_contract(&env, &token_admin);
+    let creators = [
+        Address::generate(&env),
+        Address::generate(&env),
+        Address::generate(&env),
+    ];
 
-    let wasm_hash = env.deployer().upload_contract_wasm(crowdfund_wasm::WASM);
+    let campaign1 = create_campaign(
+        &factory,
+        &creators[0],
+        &token_address,
+        &wasm_hash,
+        1000,
+        100,
+    );
+    let campaign2 = create_campaign(
+        &factory,
+        &creators[1],
+        &token_address,
+        &wasm_hash,
+        2000,
+        200,
+    );
+    let campaign3 = create_campaign(
+        &factory,
+        &creators[2],
+        &token_address,
+        &wasm_hash,
+        3000,
+        300,
+    );
 
-    // Deploy 3 campaigns with different creators.
-    let creator1 = Address::generate(&env);
-    let creator2 = Address::generate(&env);
-    let creator3 = Address::generate(&env);
-
-    let campaign1 =
-        factory.create_campaign(&creator1, &token_address, &1000i128, &100u64, &wasm_hash);
-
-    let campaign2 =
-        factory.create_campaign(&creator2, &token_address, &2000i128, &200u64, &wasm_hash);
-
-    let campaign3 =
-        factory.create_campaign(&creator3, &token_address, &3000i128, &300u64, &wasm_hash);
-
-    // Verify all campaigns are in registry.
     let campaigns = factory.campaigns();
     assert_eq!(campaigns.len(), 3);
     assert_eq!(campaigns.get(0).unwrap(), campaign1);
     assert_eq!(campaigns.get(1).unwrap(), campaign2);
     assert_eq!(campaigns.get(2).unwrap(), campaign3);
-
-    // Verify count.
     assert_eq!(factory.campaign_count(), 3);
+}
+
+#[test]
+fn test_factory_deployed_campaign_is_callable() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(true);
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let creator = Address::generate(&env);
+    let goal = 5000i128;
+    let deadline = 600u64;
+
+    let campaign_addr =
+        create_campaign(&factory, &creator, &token_address, &wasm_hash, goal, deadline);
+    let campaign = crowdfund_wasm::Client::new(&env, &campaign_addr);
+
+    assert_eq!(campaign.goal(), goal);
+    assert_eq!(campaign.deadline(), deadline);
+}
+
+#[test]
+fn test_create_campaign_rejects_missing_creator_auth() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(false);
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let creator = Address::generate(&env);
+
+    let result = factory.try_create_campaign(
+        &creator,
+        &token_address,
+        &1000i128,
+        &100u64,
+        &wasm_hash,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(factory.campaign_count(), 0);
+}
+
+#[test]
+fn test_create_campaign_rejects_non_creator_auth() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(false);
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let creator = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let goal = 1000i128;
+    let deadline = 100u64;
+
+    let result = factory
+        .mock_auths(&[MockAuth {
+            address: &attacker,
+            invoke: &MockAuthInvoke {
+                contract: &factory_id,
+                fn_name: "create_campaign",
+                args: soroban_sdk::vec![
+                    &env,
+                    creator.clone().into_val(&env),
+                    token_address.clone().into_val(&env),
+                    goal.into_val(&env),
+                    deadline.into_val(&env),
+                    wasm_hash.clone().into_val(&env),
+                ],
+                sub_invokes: &[],
+            },
+        }])
+        .try_create_campaign(&creator, &token_address, &goal, &deadline, &wasm_hash);
+
+    assert!(result.is_err());
+    assert_eq!(factory.campaign_count(), 0);
+}
+
+#[test]
+fn test_duplicate_creator_salt_collision_is_rejected_without_registry_mutation() {
+    let (env, factory_id, token_address, wasm_hash) = setup_factory(true);
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let creator = Address::generate(&env);
+
+    let first_campaign =
+        create_campaign(&factory, &creator, &token_address, &wasm_hash, 1000, 100);
+    assert_eq!(factory.campaign_count(), 1);
+
+    let result = factory.try_create_campaign(
+        &creator,
+        &token_address,
+        &2000i128,
+        &200u64,
+        &wasm_hash,
+    );
+
+    assert!(result.is_err());
+    let campaigns = factory.campaigns();
+    assert_eq!(campaigns.len(), 1);
+    assert_eq!(campaigns.get(0).unwrap(), first_campaign);
 }
 
 #[test]


### PR DESCRIPTION
closes #1261 

## Summary
- expand factory create_campaign tests for registry insertion, count increments, insertion order, callability, auth rejection, and duplicate salt collisions
- wire batch contribution tests into the factory crate
- add routing coverage for repeated multi-campaign batch contribution entries
- fix batch contribution invoke/event call shape so the tests exercise the helper cleanly

## Testing
- git diff --check
-  run: cargo test -p factory (cargo was unavailable in the previous execution environment)