### PR TITLE
fix: resolve CI formatting and clippy failures

### DIFF
--- a/apps/contracts/crowdfund/src/lib.rs
+++ b/apps/contracts/crowdfund/src/lib.rs
@@ -320,7 +320,8 @@ impl CrowdfundContract {
                 .get::<_, bool>(&DataKey::BonusGoalReachedEmitted)
                 .unwrap_or(false);
             if !already_emitted && total < bg && new_total >= bg {
-                env.events().publish(("crowdfund", "bonus_goal_reached"), bg);
+                env.events()
+                    .publish(("crowdfund", "bonus_goal_reached"), bg);
                 env.storage()
                     .instance()
                     .set(&DataKey::BonusGoalReachedEmitted, &true);
@@ -558,8 +559,7 @@ impl CrowdfundContract {
             .instance()
             .set(&DataKey::Status, &Status::Successful);
 
-        let nft_contract: Option<Address> =
-            env.storage().instance().get(&DataKey::NFTContract);
+        let nft_contract: Option<Address> = env.storage().instance().get(&DataKey::NFTContract);
         mint_nfts_in_batch(&env, &nft_contract);
 
         emit_withdrawn(&env, &creator, creator_payout, platform_fee);
@@ -820,8 +820,10 @@ impl CrowdfundContract {
             updated_fields.push_back(Symbol::new(&env, "socials"));
         }
 
-        env.events()
-            .publish(("crowdfund", "metadata_updated"), (creator.clone(), updated_fields));
+        env.events().publish(
+            ("crowdfund", "metadata_updated"),
+            (creator.clone(), updated_fields),
+        );
     }
 
     pub fn add_roadmap_item(env: Env, date: u64, description: String) {

--- a/apps/contracts/crowdfund/src/refund_single_token.md
+++ b/apps/contracts/crowdfund/src/refund_single_token.md
@@ -62,10 +62,10 @@ pub fn refund_single(env: Env, contributor: Address) -> Result<(), ContractError
    and double-claim attacks even if the token contract calls back into the
    crowdfund contract.
 
-5. **Overflow protection** — `total_raised` is decremented with `checked_sub`,
+4. **Overflow protection** — `total_raised` is decremented with `checked_sub`,
    panicking on underflow rather than silently wrapping.
 
-6. **Status guard** — `Successful` and `Cancelled` campaigns are explicitly
+5. **Status guard** — `Successful` and `Cancelled` campaigns are explicitly
    rejected. A `Refunded` campaign (set by the deprecated batch path) is
    allowed so that any contributor not swept by the batch can still claim.
 

--- a/apps/contracts/crowdfund/src/test.rs
+++ b/apps/contracts/crowdfund/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{ContractError, CrowdfundContract, CrowdfundContractClient, Status};
+use crate::{ContractError, CrowdfundContract, CrowdfundContractClient};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token, Address, Env,
@@ -380,10 +380,7 @@ fn test_contribution_after_deadline_rejected() {
 
     let result = client.try_contribute(&contributor, &10_000);
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        ContractError::CampaignEnded
-    );
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::CampaignEnded);
 }
 
 /// Contribution below min_contribution is rejected
@@ -410,10 +407,7 @@ fn test_contribution_below_minimum_rejected() {
 
     let result = client.try_contribute(&contributor, &(min_contrib - 1));
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        ContractError::BelowMinimum
-    );
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::BelowMinimum);
 }
 
 /// Zero-amount contribution is rejected
@@ -438,10 +432,7 @@ fn test_contribution_zero_amount_rejected() {
 
     let result = client.try_contribute(&contributor, &0);
     assert!(result.is_err());
-    assert_eq!(
-        result.unwrap_err().unwrap(),
-        ContractError::ZeroAmount
-    );
+    assert_eq!(result.unwrap_err().unwrap(), ContractError::ZeroAmount);
 }
 
 /// Status transitions: Active → Successful after goal met and funds withdrawn

--- a/apps/contracts/crowdfund/src/withdraw_event_emission.rs
+++ b/apps/contracts/crowdfund/src/withdraw_event_emission.rs
@@ -7,8 +7,10 @@ use crate::{DataKey, NftContractClient, MAX_NFT_MINT_BATCH};
 // ── contributed ───────────────────────────────────────────────────────────────
 
 pub fn emit_contributed(env: &Env, backer: &Address, amount: i128, total_raised: i128) {
-    env.events()
-        .publish(("crowdfund", "contributed"), (backer.clone(), amount, total_raised));
+    env.events().publish(
+        ("crowdfund", "contributed"),
+        (backer.clone(), amount, total_raised),
+    );
 }
 
 // ── goal_reached ──────────────────────────────────────────────────────────────
@@ -22,8 +24,10 @@ pub fn emit_goal_reached(env: &Env, total_raised: i128, goal: i128) {
 
 pub fn emit_withdrawn(env: &Env, creator: &Address, amount: i128, platform_fee: i128) {
     assert!(amount > 0, "withdrawn: amount must be positive");
-    env.events()
-        .publish(("crowdfund", "withdrawn"), (creator.clone(), amount, platform_fee));
+    env.events().publish(
+        ("crowdfund", "withdrawn"),
+        (creator.clone(), amount, platform_fee),
+    );
 }
 
 // ── refunded ─────────────────────────────────────────────────────────────────

--- a/apps/contracts/crowdfund/src/withdraw_event_emission_test.rs
+++ b/apps/contracts/crowdfund/src/withdraw_event_emission_test.rs
@@ -140,15 +140,17 @@ fn setup_no_nft(
 }
 
 fn topics_match(e: &soroban_sdk::xdr::ContractEvent, ns: &str, action: &str) -> bool {
-    let ContractEventBody::V0(body) = &e.body else { return false; };
-    if body.topics.len() < 2 { return false; }
+    let ContractEventBody::V0(body) = &e.body;
+    if body.topics.len() < 2 {
+        return false;
+    }
     let ns_str = ScVal::String(ScString(ns.try_into().unwrap()));
     let act_str = ScVal::String(ScString(action.try_into().unwrap()));
     body.topics[0] == ns_str && body.topics[1] == act_str
 }
 
 fn event_data_as_val(env: &Env, e: &soroban_sdk::xdr::ContractEvent) -> Val {
-    let ContractEventBody::V0(body) = &e.body else { unreachable!() };
+    let ContractEventBody::V0(body) = &e.body;
     Val::try_from_val(env, &body.data).unwrap()
 }
 
@@ -195,7 +197,15 @@ fn contributed_event_is_emitted_on_contribution() {
     let creator = Address::generate(&env);
     let deadline = env.ledger().timestamp() + 3_600;
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let backer = Address::generate(&env);
@@ -215,7 +225,15 @@ fn contributed_event_data_has_backer_amount_total_raised() {
     let creator = Address::generate(&env);
     let deadline = env.ledger().timestamp() + 3_600;
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let backer = Address::generate(&env);
@@ -240,7 +258,15 @@ fn contributed_event_total_raised_accumulates() {
     let creator = Address::generate(&env);
     let deadline = env.ledger().timestamp() + 3_600;
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let b1 = Address::generate(&env);
@@ -276,7 +302,15 @@ fn goal_reached_event_emitted_exactly_once_when_goal_met() {
     let creator = Address::generate(&env);
     let deadline = env.ledger().timestamp() + 3_600;
     client.initialize(
-        &admin, &creator, &token_addr, &500, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &500,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let b1 = Address::generate(&env);
@@ -294,8 +328,7 @@ fn goal_reached_event_emitted_exactly_once_when_goal_met() {
 
     // Verify data: total_raised and goal
     let data = first_event_data(&env, "goal_reached").expect("goal_reached not found");
-    let (total_raised, goal): (i128, i128) =
-        TryFromVal::try_from_val(&env, &data).expect("decode");
+    let (total_raised, goal): (i128, i128) = TryFromVal::try_from_val(&env, &data).expect("decode");
     assert_eq!(total_raised, 500);
     assert_eq!(goal, 500);
 }
@@ -310,7 +343,15 @@ fn goal_reached_not_emitted_when_goal_not_met() {
     let creator = Address::generate(&env);
     let deadline = env.ledger().timestamp() + 3_600;
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let backer = Address::generate(&env);
@@ -330,7 +371,15 @@ fn goal_reached_not_emitted_twice_when_exceeded() {
     let creator = Address::generate(&env);
     let deadline = env.ledger().timestamp() + 3_600;
     client.initialize(
-        &admin, &creator, &token_addr, &100, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &100,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     // Events are scoped to the last invocation: check per-call.
@@ -455,8 +504,7 @@ fn fee_transferred_event_emitted_when_platform_configured() {
     assert_eq!(count_events(&env, "fee_transferred"), 1);
 
     let data = first_event_data(&env, "fee_transferred").expect("fee_transferred not found");
-    let (_, got_fee): (Address, i128) =
-        TryFromVal::try_from_val(&env, &data).expect("decode");
+    let (_, got_fee): (Address, i128) = TryFromVal::try_from_val(&env, &data).expect("decode");
     // 2% of 1_000_000 = 20_000
     assert_eq!(got_fee, 20_000);
 }
@@ -535,7 +583,15 @@ fn refunded_event_emitted_by_refund_single() {
     let deadline = env.ledger().timestamp() + 3_600;
 
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let backer = Address::generate(&env);
@@ -567,7 +623,15 @@ fn refunded_event_emitted_per_backer_in_batch_refund() {
 
     // goal = 1000, total contributions = 600 (goal not met)
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let mut backers: std::vec::Vec<Address> = std::vec::Vec::new();
@@ -598,7 +662,15 @@ fn cancelled_event_emitted_on_cancel() {
     let deadline = env.ledger().timestamp() + 3_600;
 
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     let b = Address::generate(&env);
@@ -621,7 +693,15 @@ fn cancel_emits_refunded_for_each_contributor() {
     let deadline = env.ledger().timestamp() + 3_600;
 
     client.initialize(
-        &admin, &creator, &token_addr, &1_000, &deadline, &1_i128, &None, &None, &None,
+        &admin,
+        &creator,
+        &token_addr,
+        &1_000,
+        &deadline,
+        &1_i128,
+        &None,
+        &None,
+        &None,
     );
 
     for _ in 0..3 {

--- a/apps/contracts/factory/src/batch_contribute.rs
+++ b/apps/contracts/factory/src/batch_contribute.rs
@@ -105,6 +105,7 @@ pub fn batch_contribute(env: &Env, contributor: &Address, entries: Vec<Contribut
     }
 
     // Emit a single summary event — cheaper than one event per campaign.
+    #[allow(deprecated)]
     env.events().publish(
         (Symbol::new(env, "batch"), Symbol::new(env, "contributed")),
         (contributor.clone(), len),

--- a/apps/contracts/factory/src/lib.rs
+++ b/apps/contracts/factory/src/lib.rs
@@ -5,11 +5,11 @@ use soroban_sdk::{
 };
 
 #[cfg(test)]
-mod test;
-#[cfg(test)]
 mod batch_contribute;
 #[cfg(test)]
 mod batch_contribute_tests;
+#[cfg(test)]
+mod test;
 
 #[derive(Clone)]
 #[contracttype]

--- a/apps/contracts/factory/src/test.rs
+++ b/apps/contracts/factory/src/test.rs
@@ -61,8 +61,14 @@ fn test_create_single_campaign_registers_returned_address() {
     let goal = 1000i128;
     let deadline = 100u64;
 
-    let campaign_addr =
-        create_campaign(&factory, &creator, &token_address, &wasm_hash, goal, deadline);
+    let campaign_addr = create_campaign(
+        &factory,
+        &creator,
+        &token_address,
+        &wasm_hash,
+        goal,
+        deadline,
+    );
 
     assert_ne!(campaign_addr, factory_id);
     assert_ne!(campaign_addr, token_address);
@@ -144,8 +150,14 @@ fn test_factory_deployed_campaign_is_callable() {
     let goal = 5000i128;
     let deadline = 600u64;
 
-    let campaign_addr =
-        create_campaign(&factory, &creator, &token_address, &wasm_hash, goal, deadline);
+    let campaign_addr = create_campaign(
+        &factory,
+        &creator,
+        &token_address,
+        &wasm_hash,
+        goal,
+        deadline,
+    );
     let campaign = crowdfund_wasm::Client::new(&env, &campaign_addr);
 
     assert_eq!(campaign.goal(), goal);
@@ -158,13 +170,8 @@ fn test_create_campaign_rejects_missing_creator_auth() {
     let factory = FactoryContractClient::new(&env, &factory_id);
     let creator = Address::generate(&env);
 
-    let result = factory.try_create_campaign(
-        &creator,
-        &token_address,
-        &1000i128,
-        &100u64,
-        &wasm_hash,
-    );
+    let result =
+        factory.try_create_campaign(&creator, &token_address, &1000i128, &100u64, &wasm_hash);
 
     assert!(result.is_err());
     assert_eq!(factory.campaign_count(), 0);
@@ -208,17 +215,11 @@ fn test_duplicate_creator_salt_collision_is_rejected_without_registry_mutation()
     let factory = FactoryContractClient::new(&env, &factory_id);
     let creator = Address::generate(&env);
 
-    let first_campaign =
-        create_campaign(&factory, &creator, &token_address, &wasm_hash, 1000, 100);
+    let first_campaign = create_campaign(&factory, &creator, &token_address, &wasm_hash, 1000, 100);
     assert_eq!(factory.campaign_count(), 1);
 
-    let result = factory.try_create_campaign(
-        &creator,
-        &token_address,
-        &2000i128,
-        &200u64,
-        &wasm_hash,
-    );
+    let result =
+        factory.try_create_campaign(&creator, &token_address, &2000i128, &200u64, &wasm_hash);
 
     assert!(result.is_err());
     let campaigns = factory.campaigns();

--- a/scripts/deployment_shell_script.md
+++ b/scripts/deployment_shell_script.md
@@ -25,13 +25,13 @@ The previous `deploy.sh` used `set -e` but swallowed error context — a failed 
 ./scripts/deploy.sh [--dry-run] [--help] <creator> <token> <goal> <deadline> [min_contribution]
 ```
 
-| Argument          | Type    | Description                             |
-| :---------------- | :------ | :-------------------------------------- |
-| `creator`         | string  | Stellar address or identity of the campaign creator |
-| `token`           | string  | Stellar address of the token contract   |
-| `goal`            | integer | Funding goal in stroops                 |
-| `deadline`        | integer | Unix timestamp — must be in the future  |
-| `min_contribution`| integer | Minimum pledge amount (default: `1`)    |
+| Argument           | Type    | Description                                         |
+| :----------------- | :------ | :-------------------------------------------------- |
+| `creator`          | string  | Stellar address or identity of the campaign creator |
+| `token`            | string  | Stellar address of the token contract               |
+| `goal`             | integer | Funding goal in stroops                             |
+| `deadline`         | integer | Unix timestamp — must be in the future              |
+| `min_contribution` | integer | Minimum pledge amount (default: `1`)                |
 
 ### Flags
 
@@ -42,12 +42,12 @@ The previous `deploy.sh` used `set -e` but swallowed error context — a failed 
 
 ### Environment variables
 
-| Variable                    | Default    | Description                              |
-| :-------------------------- | :--------- | :--------------------------------------- |
-| `NETWORK`                   | `testnet`  | Stellar network to target                |
-| `STELLAR_RPC_URL`           | —          | Optional custom RPC endpoint             |
-| `STELLAR_NETWORK_PASSPHRASE`| —          | Optional network passphrase override     |
-| `SOURCE_ACCOUNT`            | —          | Optional override for the source account |
+| Variable                     | Default   | Description                              |
+| :--------------------------- | :-------- | :--------------------------------------- |
+| `NETWORK`                    | `testnet` | Stellar network to target                |
+| `STELLAR_RPC_URL`            | —         | Optional custom RPC endpoint             |
+| `STELLAR_NETWORK_PASSPHRASE` | —         | Optional network passphrase override     |
+| `SOURCE_ACCOUNT`             | —         | Optional override for the source account |
 
 ### WASM artifact check
 
@@ -71,13 +71,13 @@ A non-zero exit from this call indicates the contract did not deploy correctly a
 
 ### Exit codes
 
-| Code | Meaning                                        |
-| :--- | :--------------------------------------------- |
-| 0    | Success (or `--dry-run` / `--help`)            |
-| 1    | Missing WASM artifact                          |
-| 4    | `stellar contract deploy` failure              |
-| 5    | `stellar contract invoke initialize` failure   |
-| 6    | Post-deploy smoke check (`goal`) failed        |
+| Code | Meaning                                      |
+| :--- | :------------------------------------------- |
+| 0    | Success (or `--dry-run` / `--help`)          |
+| 1    | Missing WASM artifact                        |
+| 4    | `stellar contract deploy` failure            |
+| 5    | `stellar contract invoke initialize` failure |
+| 6    | Post-deploy smoke check (`goal`) failed      |
 
 ### Example
 
@@ -103,23 +103,23 @@ Invokes contract actions (contribute, withdraw, refund) after deployment.
 
 ### Actions
 
-| Action      | Additional args              | Description                                        |
-| :---------- | :--------------------------- | :------------------------------------------------- |
-| `contribute`| `<contributor> <amount>`     | Contribute tokens to the campaign                  |
-| `withdraw`  | `<creator>`                  | Withdraw funds (goal met and deadline passed)      |
-| `refund`    | `<caller>`                   | Refund a single contributor via `refund_single`    |
+| Action       | Additional args          | Description                                     |
+| :----------- | :----------------------- | :---------------------------------------------- |
+| `contribute` | `<contributor> <amount>` | Contribute tokens to the campaign               |
+| `withdraw`   | `<creator>`              | Withdraw funds (goal met and deadline passed)   |
+| `refund`     | `<caller>`               | Refund a single contributor via `refund_single` |
 
 ### Flags
 
-| Flag     | Description                          |
-| :------- | :----------------------------------- |
-| `--help` | Print usage documentation and exit.  |
+| Flag     | Description                         |
+| :------- | :---------------------------------- |
+| `--help` | Print usage documentation and exit. |
 
 ### Environment variables
 
-| Variable  | Default   | Description                     |
-| :-------- | :-------- | :------------------------------ |
-| `NETWORK` | `testnet` | Stellar network to target       |
+| Variable  | Default   | Description               |
+| :-------- | :-------- | :------------------------ |
+| `NETWORK` | `testnet` | Stellar network to target |
 
 ### Error output
 
@@ -156,10 +156,10 @@ All checks run before exiting — a single failure does not short-circuit the re
 
 ### Exit codes
 
-| Code | Meaning                              |
-| :--- | :----------------------------------- |
-| 0    | All checks passed                    |
-| 1    | One or more checks failed            |
+| Code | Meaning                   |
+| :--- | :------------------------ |
+| 0    | All checks passed         |
+| 1    | One or more checks failed |
 
 ---
 

--- a/scripts/wasm_build_pipeline.tsx
+++ b/scripts/wasm_build_pipeline.tsx
@@ -640,7 +640,6 @@ export const scriptBuildCache = new ScriptBuildCache();
 
 export default WasmBuildCache;
 
-
 /**
  * WASM Build Pipeline Constants for Stellar Raise Contracts
  * Extracted from Cargo.toml [profile.release], .cargo/config.toml, and build scripts.


### PR DESCRIPTION
## Summary
- `cargo fmt --all` had drifted out of sync with recently merged PRs, breaking the formatting gate on every push to `main` (Rust CI).
- `prettier --check .` was failing on 3 files (`refund_single_token.md`, `deployment_shell_script.md`, `wasm_build_pipeline.tsx`) (Frontend CI).
- Fixed 3 clippy `-D warnings` errors that were only surfaced locally once formatting passed: an unused `Status` import in `crowdfund/src/test.rs`, a deprecated `Events::publish` call in `factory/src/batch_contribute.rs` missing `#[allow(deprecated)]` (consistent with the rest of the codebase), and two `let-else` patterns in `withdraw_event_emission_test.rs` that became irrefutable after an xdr type change.

No behavioral changes — formatting and lint fixes only.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test -p crowdfund` — 69 passed
- [x] `pnpm format:check` passes
- [x] `pnpm --filter @stellar-raise/frontend typecheck` / `test` (375 passed) / `lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)