### PR TITLE
fix: canonicalize WASM encoding and fix batch_contribute test harness

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -84,7 +84,7 @@ jobs:
         # feature itself is unused. Round-tripping through wasm-opt re-emits
         # the binary with canonical (minimal) LEB128 encoding.
         run: |
-          wasm-opt -O0 \
+          wasm-opt -O0 --enable-sign-ext \
             target/wasm32-unknown-unknown/release/crowdfund.wasm \
             -o target/wasm32-unknown-unknown/release/crowdfund.wasm
 

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -74,6 +74,20 @@ jobs:
         timeout-minutes: 10
         run: cargo build --release --target wasm32-unknown-unknown -p crowdfund
 
+      - name: Install wasm-opt (Binaryen)
+        run: sudo apt-get install -y binaryen
+
+      - name: Canonicalize WASM encoding
+        # Some rustc/LLVM releases emit call_indirect with an overlong LEB128
+        # table-index immediate. soroban-env-host's wasm parser rejects that
+        # ("reference-types not enabled: zero byte expected") even though the
+        # feature itself is unused. Round-tripping through wasm-opt re-emits
+        # the binary with canonical (minimal) LEB128 encoding.
+        run: |
+          wasm-opt -O0 \
+            target/wasm32-unknown-unknown/release/crowdfund.wasm \
+            -o target/wasm32-unknown-unknown/release/crowdfund.wasm
+
       - name: Run Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
@@ -107,9 +121,6 @@ jobs:
 
       - name: Report WASM binary size
         run: ls -lh target/wasm32-unknown-unknown/release/crowdfund.wasm
-
-      - name: Install wasm-opt (Binaryen)
-        run: sudo apt-get install -y binaryen
 
       - name: Optimize WASM with wasm-opt
         run: |

--- a/apps/contracts/factory/src/batch_contribute_tests.rs
+++ b/apps/contracts/factory/src/batch_contribute_tests.rs
@@ -46,13 +46,30 @@ impl MockCampaign {
     }
 }
 
+// ── Harness ──────────────────────────────────────────────────────────────────
+// `batch_contribute` calls `env.invoke_contract`, which requires a currently
+// executing contract. Production code only ever calls it from within
+// `FactoryContract`, so the harness reproduces that calling context.
+
+#[contract]
+struct Harness;
+
+#[contractimpl]
+impl Harness {
+    pub fn run(env: Env, contributor: Address, entries: Vec<ContributeEntry>) {
+        batch_contribute(&env, &contributor, entries);
+    }
+}
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-fn setup() -> (Env, Address) {
+fn setup() -> (Env, HarnessClient<'static>, Address) {
     let env = Env::default();
     env.mock_all_auths();
+    let harness_id = env.register(Harness, ());
+    let harness = HarnessClient::new(&env, &harness_id);
     let contributor = Address::generate(&env);
-    (env, contributor)
+    (env, harness, contributor)
 }
 
 fn register_campaign(env: &Env) -> Address {
@@ -67,13 +84,13 @@ fn entry(campaign: Address, amount: i128) -> ContributeEntry {
 
 #[test]
 fn batch_single_entry_succeeds() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let c1 = register_campaign(&env);
 
     let mut entries = Vec::new(&env);
     entries.push_back(entry(c1.clone(), 1_000));
 
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 
     let client = MockCampaignClient::new(&env, &c1);
     assert_eq!(client.total(), 1_000);
@@ -81,7 +98,7 @@ fn batch_single_entry_succeeds() {
 
 #[test]
 fn batch_multiple_campaigns_all_funded() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let c1 = register_campaign(&env);
     let c2 = register_campaign(&env);
     let c3 = register_campaign(&env);
@@ -91,7 +108,7 @@ fn batch_multiple_campaigns_all_funded() {
     entries.push_back(entry(c2.clone(), 1_500));
     entries.push_back(entry(c3.clone(), 2_000));
 
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 
     assert_eq!(MockCampaignClient::new(&env, &c1).total(), 500);
     assert_eq!(MockCampaignClient::new(&env, &c2).total(), 1_500);
@@ -100,7 +117,7 @@ fn batch_multiple_campaigns_all_funded() {
 
 #[test]
 fn batch_routes_repeated_entries_to_their_target_campaigns() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let c1 = register_campaign(&env);
     let c2 = register_campaign(&env);
 
@@ -109,7 +126,7 @@ fn batch_routes_repeated_entries_to_their_target_campaigns() {
     entries.push_back(entry(c2.clone(), 750));
     entries.push_back(entry(c1.clone(), 1_250));
 
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 
     assert_eq!(MockCampaignClient::new(&env, &c1).total(), 1_500);
     assert_eq!(MockCampaignClient::new(&env, &c2).total(), 750);
@@ -117,52 +134,52 @@ fn batch_routes_repeated_entries_to_their_target_campaigns() {
 
 #[test]
 fn batch_at_max_size_succeeds() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let mut entries = Vec::new(&env);
     for _ in 0..MAX_BATCH_SIZE {
         let c = register_campaign(&env);
         entries.push_back(entry(c, 100));
     }
     // Must not panic.
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 }
 
 #[test]
 #[should_panic(expected = "batch exceeds MAX_BATCH_SIZE")]
 fn batch_over_max_size_panics() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let mut entries = Vec::new(&env);
     for _ in 0..MAX_BATCH_SIZE + 1 {
         let c = register_campaign(&env);
         entries.push_back(entry(c, 100));
     }
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 }
 
 #[test]
 #[should_panic(expected = "batch is empty")]
 fn batch_empty_panics() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let entries: Vec<ContributeEntry> = Vec::new(&env);
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 }
 
 #[test]
 #[should_panic(expected = "batch entry amount must be positive")]
 fn batch_zero_amount_entry_panics() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let c1 = register_campaign(&env);
     let mut entries = Vec::new(&env);
     entries.push_back(entry(c1, 0));
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 }
 
 #[test]
 #[should_panic(expected = "batch entry amount must be positive")]
 fn batch_negative_amount_entry_panics() {
-    let (env, contributor) = setup();
+    let (env, harness, contributor) = setup();
     let c1 = register_campaign(&env);
     let mut entries = Vec::new(&env);
     entries.push_back(entry(c1, -500));
-    batch_contribute(&env, &contributor, entries);
+    harness.run(&contributor, &entries);
 }


### PR DESCRIPTION
## Summary
After #1278 fixed the formatting gate, the merge run still failed at the
test step (run [27870308289](https://github.com/Crowdfunding-DApp/stellar-raise-contracts/actions/runs/27870308289)):

1. **All `factory::test::*` tests failed** with `soroban-env-host` rejecting the
   built `crowdfund.wasm`: `"reference-types not enabled: zero byte expected"`.
   Root cause: a recent rustc/LLVM release on the runner's `stable` toolchain
   emits `call_indirect` with an overlong (multi-byte) LEB128 table-index
   immediate. The wasm spec requires that immediate to be a single canonical
   zero byte when `reference-types` is disabled, and `soroban-env-host`'s
   parser enforces that strictly. Disabling the codegen feature via `-C
   target-feature=-call-indirect-overlong` has no effect — it's gated behind
   nightly and silently ignored on stable. Confirmed locally with `wasm-tools`/
   `wasm-opt`: round-tripping the binary through either re-serializes it with
   canonical encoding and fixes the validation error. `rust_ci.yml` now runs
   `wasm-opt -O0` on `crowdfund.wasm` right after building it, before it's
   used by clippy/tests/tarpaulin (moved the existing `Install wasm-opt` step
   up rather than installing it twice).
2. **All `batch_contribute_tests::*` failed** with `HostError: ... "no contract
   running"`. These tests called the `batch_contribute()` free function
   directly from the test body, but that function calls
   `env.invoke_contract()`, which requires a currently executing contract —
   production code only ever reaches it from within `FactoryContract`. Added a
   thin `Harness` contract so the tests invoke it through a `Client`, matching
   how it's actually called.

No behavioral or contract-API changes — CI tooling + test-harness fixes only.

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --workspace` — 92 passed (69 crowdfund + 16 factory + 7 soroban_sdk_minor), 0 failed
- [x] Verified locally that `wasm-opt -O0` round-trip fixes `wasm-tools validate --features=-reference-types,-multi-value`

🤖 Generated with [Claude Code](https://claude.com/claude-code)