### PR TITLE
fix: pass --enable-sign-ext to the wasm-opt canonicalization step

### DIFF
--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -84,7 +84,7 @@ jobs:
         # feature itself is unused. Round-tripping through wasm-opt re-emits
         # the binary with canonical (minimal) LEB128 encoding.
         run: |
-          wasm-opt -O0 \
+          wasm-opt -O0 --enable-sign-ext \
             target/wasm32-unknown-unknown/release/crowdfund.wasm \
             -o target/wasm32-unknown-unknown/release/crowdfund.wasm
 


### PR DESCRIPTION
## Summary
Follow-up on #1279 — the Rust CI run on that PR's merge commit still failed,
this time at the new "Canonicalize WASM encoding" step itself:

```
[wasm-validator error in function 333] unexpected false: all used features should be allowed, on
(i32.extend8_s
 (local.get $5)
)
```

The CI runner's `apt`-installed `binaryen` validates the input against its
default (MVP-only) feature set even with `-O0`/no optimization passes, and
rejects `crowdfund.wasm` because rustc emits `i32.extend8_s` (the
sign-extension proposal, enabled by default on `wasm32-unknown-unknown`).
The existing later size-check step already passes `--enable-sign-ext` for
the same reason — this just applies it to the new earlier step too.

Confirmed locally with `wasm-tools validate --features=mvp,sign-extension,...`
that sign-extension is the only non-MVP feature actually used by the binary,
so no other flags are needed.

## Test plan
- [x] `cargo test --workspace` — 92 passed, 0 failed
- [x] Verified locally that `wasm-opt -O0 --enable-sign-ext` round-trips the binary without validation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)