### PR TITLE
fix: unbreak Rust CI and Spellcheck on main

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -224,6 +224,7 @@
     "vite",
     "vitejs",
     "deserialising",
-    "deserialisation"
+    "deserialisation",
+    "underbanked"
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -631,9 +631,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "factory"


### PR DESCRIPTION
## Summary
- Bump `ethnum` 1.5.2 → 1.5.3 (`Cargo.lock` only, no manifest range change). 1.5.2's `TryFromIntError::from(Infallible)` impl does `unsafe { mem::transmute(()) }`, assuming `TryFromIntError` is zero-sized; that assumption breaks under the current rustc, so the `crowdfund` WASM build fails with `E0512` in CI. 1.5.3 fixes this upstream.
- Add `"underbanked"` to `.cspell.json` — it's used in `stellar_solution.md` and was failing the Spellcheck workflow.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --release --target wasm32-unknown-unknown -p crowdfund`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `wasm-opt -O0 --enable-sign-ext …` canonicalization + `PROPTEST_CASES=1000 cargo test --workspace` (92 tests passing)
- [x] `cargo doc --no-deps --workspace`
- [x] WASM size check (37,716 bytes, well under the 256 KB cap)
- [x] Confirmed `underbanked` is the only unknown word flagged by cspell

🤖 Generated with [Claude Code](https://claude.com/claude-code)