### PR TITLE
fix: reject fee_bps == 10_000 (100%) in platform fee validation

### DIFF
--- a/apps/contracts/crowdfund/src/access_control.rs
+++ b/apps/contracts/crowdfund/src/access_control.rs
@@ -20,6 +20,7 @@
 
 use soroban_sdk::{Address, Env, Symbol};
 
+use crate::campaign_goal_minimum::validate_platform_fee;
 use crate::{ContractError, DataKey, PlatformConfig};
 
 // ── Role helpers ─────────────────────────────────────────────────────────────
@@ -134,10 +135,14 @@ pub fn is_paused(env: &Env) -> bool {
 ///
 /// # Arguments
 /// * `caller` – Must match the stored `GovernanceAddress`.
-/// * `config` – New fee config; `fee_bps` must be <= 10_000 (100%).
+/// * `config` – New fee config; `fee_bps` must be < 10_000 (100%).
 ///
 /// # Errors
-/// * [`ContractError::InvalidPlatformFee`] if `fee_bps > 10_000`.
+/// * [`ContractError::InvalidPlatformFee`] if `fee_bps >= 10_000`. Delegates to
+///   [`validate_platform_fee`] rather than re-checking the threshold inline so
+///   this path can never drift from the initialization-time check (audit #31
+///   found the two had already diverged: this function used to accept exactly
+///   100%, permitting a full-drain config via a governance update).
 ///
 /// # Security
 /// - `caller.require_auth()` ensures the governance multisig signed the tx.
@@ -154,9 +159,7 @@ pub fn set_platform_fee(
         panic!("only GovernanceAddress can set platform fee");
     }
 
-    if config.fee_bps > 10_000 {
-        return Err(ContractError::InvalidPlatformFee);
-    }
+    validate_platform_fee(config.fee_bps).map_err(|_| ContractError::InvalidPlatformFee)?;
 
     env.storage()
         .instance()

--- a/apps/contracts/crowdfund/src/campaign_goal_minimum.rs
+++ b/apps/contracts/crowdfund/src/campaign_goal_minimum.rs
@@ -33,8 +33,9 @@
 //!    allow the creator to withdraw dust amounts.
 //! 2. `MIN_CONTRIBUTION_AMOUNT` prevents zero-amount contributions that waste
 //!    gas on a no-op token transfer and pollute the contributors list.
-//! 3. `MAX_PLATFORM_FEE_BPS` caps the platform fee at 100 % (10 000 bps) so
-//!    the contract can never be configured to steal all contributor funds.
+//! 3. `MAX_PLATFORM_FEE_BPS` caps the platform fee *below* 100 % (10 000 bps)
+//!    so the contract can never be configured to leave the creator with a
+//!    zero payout — a fee equal to 100 % is rejected, not just fees above it.
 //! 4. `PROGRESS_BPS_SCALE` is the single authoritative scale factor for all
 //!    basis-point progress calculations; using it everywhere prevents
 //!    off-by-one errors when the scale changes.
@@ -59,7 +60,7 @@
 //!        │                              ──► Ok / Err::DeadlineTooSoon
 //!        │
 //!        └─► validate_platform_fee(fee_bps)
-//!                └─ fee_bps <= MAX_PLATFORM_FEE_BPS
+//!                └─ fee_bps < MAX_PLATFORM_FEE_BPS
 //!                               ──► Ok / Err::FeeTooHigh
 //! ```
 
@@ -79,10 +80,13 @@ pub const MIN_GOAL_AMOUNT: i128 = 1;
 /// would allow zero-amount contributions to waste gas and pollute storage.
 pub const MIN_CONTRIBUTION_AMOUNT: i128 = 1;
 
-/// Maximum platform fee expressed in basis points (1 bps = 0.01 %).
+/// Basis-point scale representing 100 % — also the exclusive ceiling for
+/// `fee_bps` (1 bps = 0.01 %).
 ///
-/// 10 000 bps == 100 %.  A fee above this would mean the platform takes more
-/// than the total raised, leaving the creator with a negative payout.
+/// `validate_platform_fee` rejects `fee_bps >= MAX_PLATFORM_FEE_BPS`, not just
+/// `>`. A fee *equal to* 10 000 bps (100 %) would let the platform take the
+/// entire amount raised, leaving the creator with a payout of exactly zero —
+/// audit #31. The valid range is therefore `[0, MAX_PLATFORM_FEE_BPS)`.
 pub const MAX_PLATFORM_FEE_BPS: u32 = 10_000;
 
 /// Scale factor used for all basis-point progress calculations.
@@ -151,14 +155,19 @@ pub fn validate_deadline(now: u64, deadline: u64) -> Result<(), &'static str> {
     Ok(())
 }
 
-/// Validates that a platform fee does not exceed the maximum allowed.
+/// Validates that a platform fee stays strictly below 100 %.
 ///
 /// @param  fee_bps  Platform fee in basis points.
-/// @return          `Ok(())` if `fee_bps <= MAX_PLATFORM_FEE_BPS`.
+/// @return          `Ok(())` if `fee_bps < MAX_PLATFORM_FEE_BPS`.
+///
+/// @dev    Uses `>=` rather than `>` so that `fee_bps == MAX_PLATFORM_FEE_BPS`
+///         (100 %) is rejected. A 100 % fee would leave the creator with a
+///         payout of exactly zero — i.e. a full-drain platform config
+///         (audit #31) — even though it never exceeds the nominal cap.
 #[inline]
 pub fn validate_platform_fee(fee_bps: u32) -> Result<(), &'static str> {
-    if fee_bps > MAX_PLATFORM_FEE_BPS {
-        return Err("platform fee cannot exceed MAX_PLATFORM_FEE_BPS (100%)");
+    if fee_bps >= MAX_PLATFORM_FEE_BPS {
+        return Err("platform fee must be strictly below MAX_PLATFORM_FEE_BPS (100%)");
     }
     Ok(())
 }
@@ -186,5 +195,52 @@ pub fn compute_progress_bps(total_raised: i128, goal: i128) -> u32 {
         MAX_PROGRESS_BPS
     } else {
         raw as u32
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    // ── validate_platform_fee ───────────────────────────────────────────────
+    //
+    // Regression coverage for audit #31: `fee_bps == MAX_PLATFORM_FEE_BPS`
+    // (100%) must be rejected, not accepted. A 100% fee means
+    // `creator_payout = total - fee == 0` in `lib.rs::withdraw` — a full
+    // drain to the platform address.
+
+    #[test]
+    fn validate_platform_fee_accepts_zero() {
+        assert!(validate_platform_fee(0).is_ok());
+    }
+
+    #[test]
+    fn validate_platform_fee_accepts_typical_fee() {
+        assert!(validate_platform_fee(250).is_ok()); // 2.5%
+    }
+
+    #[test]
+    fn validate_platform_fee_accepts_one_below_cap() {
+        assert!(validate_platform_fee(MAX_PLATFORM_FEE_BPS - 1).is_ok());
+    }
+
+    #[test]
+    fn validate_platform_fee_rejects_exact_cap() {
+        // This is the audit #31 regression case: 100% must NOT validate.
+        let err = validate_platform_fee(MAX_PLATFORM_FEE_BPS).unwrap_err();
+        assert!(
+            err.contains("MAX_PLATFORM_FEE_BPS"),
+            "error should mention MAX_PLATFORM_FEE_BPS, got: {err}"
+        );
+    }
+
+    #[test]
+    fn validate_platform_fee_rejects_one_above_cap() {
+        assert!(validate_platform_fee(MAX_PLATFORM_FEE_BPS + 1).is_err());
+    }
+
+    #[test]
+    fn validate_platform_fee_rejects_u32_max() {
+        assert!(validate_platform_fee(u32::MAX).is_err());
     }
 }

--- a/apps/contracts/crowdfund/src/crowdfund_initialize_function.rs
+++ b/apps/contracts/crowdfund/src/crowdfund_initialize_function.rs
@@ -40,7 +40,9 @@ pub struct InitParams {
     pub deadline: u64,
     /// Minimum single contribution. Must be >= 1.
     pub min_contribution: i128,
-    /// Optional platform fee configuration. `fee_bps` must be <= 10_000.
+    /// Optional platform fee configuration. `fee_bps` must be < 10_000 (100%
+    /// is rejected — see audit #31, a fee of exactly 100% leaves the creator
+    /// with a zero payout).
     pub platform_config: Option<PlatformConfig>,
     /// Optional bonus goal. When provided, must be > `goal`.
     pub bonus_goal: Option<i128>,
@@ -193,7 +195,7 @@ pub fn describe_init_error(code: u32) -> &'static str {
         8 => "Campaign goal must be at least 1",
         9 => "Minimum contribution must be at least 1",
         10 => "Deadline must be at least 60 seconds in the future",
-        11 => "Platform fee cannot exceed 100% (10,000 bps)",
+        11 => "Platform fee must be below 100% (10,000 bps)",
         12 => "Bonus goal must be strictly greater than the primary goal",
         _ => "Unknown initialization error",
     }

--- a/apps/contracts/crowdfund/src/lib.rs
+++ b/apps/contracts/crowdfund/src/lib.rs
@@ -150,7 +150,7 @@ pub enum ContractError {
     InvalidMinContribution = 9,
     /// deadline must be at least MIN_DEADLINE_OFFSET seconds in the future
     DeadlineTooSoon = 10,
-    /// platform fee_bps must be <= 10_000
+    /// platform fee_bps must be < 10_000 (100% is rejected, audit #31)
     InvalidPlatformFee = 11,
     /// bonus_goal must be strictly greater than goal
     InvalidBonusGoal = 12,
@@ -185,7 +185,8 @@ impl CrowdfundContract {
     ///
     /// # Panics
     /// * If already initialized.
-    /// * If platform fee exceeds 10,000 (100%).
+    /// * If platform fee is >= 10,000 (100%) — a fee of exactly 100% would
+    ///   leave the creator with a zero payout (audit #31).
     /// * If bonus goal is not greater than the primary goal.
     pub fn initialize(
         env: Env,

--- a/apps/contracts/crowdfund/src/test.rs
+++ b/apps/contracts/crowdfund/src/test.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use crate::{ContractError, CrowdfundContract, CrowdfundContractClient};
+use crate::{ContractError, CrowdfundContract, CrowdfundContractClient, PlatformConfig};
 use soroban_sdk::{
     testutils::{Address as _, Ledger},
     token, Address, Env,
@@ -500,4 +500,75 @@ fn test_multiple_contributions_same_backer() {
     client.contribute(&contributor, &150_000);
     assert_eq!(client.contribution(&contributor), 450_000);
     assert_eq!(client.total_raised(), 450_000);
+}
+
+// ── Audit #31 regression: fee_bps == 10_000 (100%) full-drain config ──────────
+
+/// A `fee_bps` of exactly 10_000 (100%) must be rejected at `initialize()`.
+///
+/// Before the fix, `validate_platform_fee` accepted `fee_bps ==
+/// MAX_PLATFORM_FEE_BPS`, so this platform config would pass validation and
+/// leave `creator_payout = total - fee == 0` in `withdraw()` — a full drain
+/// to the platform address.
+#[test]
+fn test_initialize_rejects_full_drain_platform_fee() {
+    let (env, client, platform_admin, creator, token_address, _token_client) = setup_env();
+    let deadline = env.ledger().timestamp() + 3600;
+
+    let result = client.try_initialize(
+        &platform_admin,
+        &creator,
+        &token_address,
+        &1_000_000,
+        &deadline,
+        &1_000,
+        &Some(PlatformConfig {
+            address: platform_admin.clone(),
+            fee_bps: 10_000,
+        }),
+        &None,
+        &None,
+    );
+
+    assert_eq!(
+        result.unwrap_err().unwrap(),
+        ContractError::InvalidPlatformFee
+    );
+}
+
+/// The new maximum valid fee (`MAX_PLATFORM_FEE_BPS - 1` = 9_999 bps) must
+/// still leave the creator with a strictly positive payout after `withdraw()`.
+#[test]
+fn test_withdraw_with_max_valid_fee_leaves_nonzero_creator_payout() {
+    let (env, client, platform_admin, creator, token_address, token_client) = setup_env();
+    let deadline = env.ledger().timestamp() + 3600;
+    let goal = 1_000_000;
+
+    client.initialize(
+        &platform_admin,
+        &creator,
+        &token_address,
+        &goal,
+        &deadline,
+        &1_000,
+        &Some(PlatformConfig {
+            address: platform_admin.clone(),
+            fee_bps: 9_999,
+        }),
+        &None,
+        &None,
+    );
+
+    let contributor = Address::generate(&env);
+    token_client.mint(&contributor, &goal);
+    client.contribute(&contributor, &goal);
+
+    env.ledger().set_timestamp(deadline + 1);
+    client.withdraw();
+
+    let token = token::Client::new(&env, &token_address);
+    assert!(
+        token.balance(&creator) > 0,
+        "creator payout must be strictly positive, even at the maximum valid fee"
+    );
 }


### PR DESCRIPTION
## Summary

Closes #1347 ([Audit #31] `fee_bps == 10_000` (100%) passes validation, permitting a full-drain platform config).

`validate_platform_fee` used `fee_bps > MAX_PLATFORM_FEE_BPS`, so a fee of exactly 10,000 bps (100%) passed validation. In `withdraw()`, that produces `creator_payout = total - fee == 0` — a platform config that fully drains every campaign to the platform address, leaving the creator with nothing.

- `campaign_goal_minimum::validate_platform_fee` (the live validation path, used by `execute_initialize`) now rejects `fee_bps >= MAX_PLATFORM_FEE_BPS`.
- `access_control::set_platform_fee` — the governance fee-update path for #16 — had independently duplicated the same check with a hardcoded `10_000` literal, and had the identical bug. It now delegates to `validate_platform_fee` instead of re-checking the threshold inline, so the two paths can't diverge again. Note: `access_control.rs` is not currently wired into `lib.rs` as a module, so this path is not yet live in the deployed contract — the fix is there for whenever it is wired in.

The bound chosen is intentionally minimal: `fee_bps` must be strictly below 100%, guaranteeing a non-zero creator payout. The issue itself flags that a tighter, product-driven economic ceiling is a separate decision (and should be reconciled with #16); this PR only closes the "payout of exactly zero" hole.

## Test plan

- [x] `cargo test -p crowdfund` — 77/77 passing, including new regression coverage:
  - Unit tests in `campaign_goal_minimum.rs` for the new boundary (accepts `MAX_PLATFORM_FEE_BPS - 1`, rejects `MAX_PLATFORM_FEE_BPS`, still rejects `MAX_PLATFORM_FEE_BPS + 1`).
  - Integration test in `test.rs`: `initialize()` rejects a `fee_bps: 10_000` platform config with `ContractError::InvalidPlatformFee`.
  - Integration test in `test.rs`: full `initialize()` → `contribute()` → `withdraw()` lifecycle at the new maximum valid fee (9,999 bps) asserts the creator's token balance is strictly positive afterward.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p crowdfund --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)